### PR TITLE
A-1206522048129359 | Tooltip cut-off in Drug Chart

### DIFF
--- a/src/features/DisplayControls/DrugChart/components/DrugListCell.jsx
+++ b/src/features/DisplayControls/DrugChart/components/DrugListCell.jsx
@@ -117,6 +117,7 @@ export default function DrugListCell(props) {
               <TooltipDefinition
                 tooltipText={getToolTipTextForAdministeredTime()}
                 className={"administration-details-tooltip"}
+                direction="top"
               >
                 <div className={"administration-time-info"}>
                   <Clock className={"clock-icon"} />

--- a/src/features/DisplayControls/DrugChart/styles/DrugListCell.scss
+++ b/src/features/DisplayControls/DrugChart/styles/DrugListCell.scss
@@ -25,6 +25,10 @@
     gap: 5px;
     .administration-details-tooltip {
       width: 100%;
+      [id*="definition-tooltip-"] {
+        color: #fff;
+        font-size: 0.75rem;
+      }
     }
     .administration-time-info {
       white-space: nowrap;
@@ -51,6 +55,10 @@
 
 .name-tooltip {
   max-width: 100%;
+  [id*="definition-tooltip-"] {
+    color: #fff;
+    font-size: 0.875rem;
+  }
 }
 
 .dosage {

--- a/src/features/DisplayControls/DrugChart/tests/__snapshots__/DrugListCell.spec.js.snap
+++ b/src/features/DisplayControls/DrugChart/tests/__snapshots__/DrugListCell.spec.js.snap
@@ -116,7 +116,7 @@ exports[`DrugListCell should  match snapshot for drug cell with admin info statu
           >
             <button
               aria-describedby="definition-tooltip-5"
-              class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+              class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
               type="button"
             >
               <div
@@ -214,7 +214,7 @@ exports[`DrugListCell should  match snapshot for for drug cell with admin info s
           >
             <button
               aria-describedby="definition-tooltip-3"
-              class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--bottom bx--tooltip--align-start"
+              class="bx--tooltip__trigger bx--tooltip--a11y bx--tooltip__trigger--definition bx--tooltip--top bx--tooltip--align-start"
               type="button"
             >
               <div


### PR DESCRIPTION
This PR has changes to fix bug in tooltip not showing up properly for single medication in drug chart

## Screenshots

<img width="787" alt="image" src="https://github.com/Bahmni/openmrs-module-ipd-frontend/assets/91885483/54792b9f-d276-4e6d-9729-cfe01e579dfe">
<img width="671" alt="image" src="https://github.com/Bahmni/openmrs-module-ipd-frontend/assets/91885483/9068f0f1-0286-439b-ad90-acb665ac87f0">
