### PR TITLE
BAH-3648 | Add. Event Trigger To Publish openmrs-module-ipd-frontend

### DIFF
--- a/.github/workflows/build_publish.yml
+++ b/.github/workflows/build_publish.yml
@@ -5,6 +5,11 @@ on:
       - main
     paths-ignore:
       - "**.md"
+  workflow_run:
+    workflows: [Pull Translations from Transifex]
+    types: [completed]
+    branches:
+      - main
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
JIRA -> [BAH-3648](https://bahmni.atlassian.net/browse/BAH-3648)

In this PR, an workflow based event trigger has been added to the Build and Publish openmrs-module-ipd-frontend workflow. The Build and Publish openmrs-module-ipd-frontend workflow was not getting triggered as the commit action in the Pull Translations From Transifex workflow run can’t trigger a new workflow run [(Refer comment)](https://github.com/orgs/community/discussions/27028#discussioncomment-3254360). The changes added will programmatically trigger Build and Publish openmrs-module-ipd-frontend once the Pull Translations From Transifex workflow is successfully completed.