### PR TITLE
BAH-3708 | Add. Transifex Resource for openmrs-module-ipd-frontend

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -1,11 +1,13 @@
 [main]
 host = https://www.transifex.com
 
-[o:openmrs:p:bahmni:r:admin-app]
+[o:openmrs:p:bahmni:r:ipd-frontend]
 file_filter            = public/i18n/locale_<lang>.json
 source_file            = public/i18n/locale_en.json
 source_lang            = en
 type                   = KEYVALUEJSON
+minimum_perc           = 0
+resource_name          = IPD Front-End
 replace_edited_strings = false
 keep_translations      = false
 


### PR DESCRIPTION
JIRA -> [BAH-3708](https://bahmni.atlassian.net/browse/BAH-3708)

In this PR, we have created a new Transifex resource specifically for `openmrs-module-ipd-frontend` called IPD Front-End (slug - `ipd-frontend`). This will allow us to manage translations for this module separately and prevent any unintentional overwriting of source files.