### PR TITLE
Kavitha|A-1207076536340634|fix disable save when drug is not given

### DIFF
--- a/src/features/DisplayControls/NursingTasks/components/AddEmergencyTasks.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/AddEmergencyTasks.jsx
@@ -170,6 +170,8 @@ const AddEmergencyTasks = (props) => {
         }
         setRoutes({ label: route, value: route });
       }
+    } else {
+      setSelectedDrug({});
     }
   };
 
@@ -322,6 +324,7 @@ const AddEmergencyTasks = (props) => {
       administrationDate &&
       !isInvalidTime &&
       !(
+        _.isEmpty(selectedDrug) ||
         _.isEmpty(doseUnits) ||
         _.isEmpty(routes) ||
         _.isEmpty(requestedProvider) ||
@@ -337,6 +340,7 @@ const AddEmergencyTasks = (props) => {
         dosage ||
         isDateChanged ||
         isTimeChanged ||
+        !_.isEmpty(selectedDrug) ||
         !_.isEmpty(doseUnits) ||
         !_.isEmpty(routes) ||
         !_.isEmpty(requestedProvider) ||


### PR DESCRIPTION
-Save button should be disabled if the medication name is not added
Bug card - https://app.asana.com/0/1204322126657135/1207076536340634/f