### PR TITLE
[Sri] - Fix drug chart issue for shift timing ending in half-an-hour

### DIFF
--- a/src/features/DisplayControls/DrugChart/components/Calendar.jsx
+++ b/src/features/DisplayControls/DrugChart/components/Calendar.jsx
@@ -3,7 +3,7 @@ import PropTypes from "prop-types";
 import CalendarRow from "./CalendarRow.jsx";
 import "../styles/Calendar.scss";
 export default function Calendar(props) {
-  const { calendarData, currentShiftArray, selectedDate } = props;
+  const { calendarData, currentShiftArray, selectedDate, shiftIndex } = props;
   return (
     <table className="drug-chart-calendar">
       <tbody>
@@ -14,6 +14,7 @@ export default function Calendar(props) {
                 rowData={rowData}
                 currentShiftArray={currentShiftArray}
                 selectedDate={selectedDate}
+                shiftIndex={shiftIndex}
               />
             </tr>
           );
@@ -27,4 +28,5 @@ Calendar.propTypes = {
   calendarData: PropTypes.array.isRequired,
   currentShiftArray: PropTypes.array,
   selectedDate: PropTypes.instanceOf(Date),
+  shiftIndex: PropTypes.number,
 };

--- a/src/features/DisplayControls/DrugChart/components/CalendarHeader.jsx
+++ b/src/features/DisplayControls/DrugChart/components/CalendarHeader.jsx
@@ -2,17 +2,22 @@ import React, { useContext } from "react";
 import PropTypes from "prop-types";
 import "../styles/CalendarHeader.scss";
 import { IPDContext } from "../../../../context/IPDContext";
-import { getFormattedDateTime } from "../../../../utils/DateTimeUtils";
+import {
+  add30Minutes,
+  getFormattedDateTime,
+} from "../../../../utils/DateTimeUtils";
 
 export default function CalendarHeader(props) {
   const { config } = useContext(IPDContext);
   const { enable24HourTime = {} } = config;
   const { currentShiftArray } = props;
 
+  const updatedCurrentShiftArray = currentShiftArray.flatMap(add30Minutes);
+
   return (
     <div className="calendar-header">
       <div style={{ display: "flex" }}>
-        {currentShiftArray.map((time) => {
+        {updatedCurrentShiftArray.map((time) => {
           const [hour, minute] = time.split(":");
           const transformedTime = getFormattedDateTime(
             hour,

--- a/src/features/DisplayControls/DrugChart/components/CalendarRow.jsx
+++ b/src/features/DisplayControls/DrugChart/components/CalendarRow.jsx
@@ -16,7 +16,8 @@ export default function CalendarRow(props) {
   const shiftArray = Object.values(shiftConfig);
   const shiftEndTime = shiftArray[shiftIndex].shiftEndTime;
   const endTime = moment(shiftEndTime, "HH:mm");
-  const isWholeHourEndTime = endTime.minutes() === 0;
+  const startTime = moment(currentShiftArray[0], "HH:mm");
+  const hasMinutes = endTime.minutes() - startTime.minutes() !== 0;
   const isWholeHourStartTime = Number(currentShiftMinute) === 0;
   slots.forEach((slot) => {
     let time;
@@ -87,10 +88,7 @@ export default function CalendarRow(props) {
               key={time}
               doHighlightCell={isCurrentHour}
               highlightedCell={highlightedCell}
-              isBlank={
-                index === currentShiftArray.length - 1 &&
-                !!(isWholeHourEndTime ^ isWholeHourStartTime)
-              }
+              isBlank={index === currentShiftArray.length - 1 && hasMinutes}
               isWholeHourStartTime={isWholeHourStartTime}
             />
           );
@@ -100,10 +98,7 @@ export default function CalendarRow(props) {
             key={time}
             doHighlightCell={isCurrentHour}
             highlightedCell={highlightedCell}
-            isBlank={
-              index === currentShiftArray.length - 1 &&
-              !!(isWholeHourEndTime ^ isWholeHourStartTime)
-            }
+            isBlank={index === currentShiftArray.length - 1 && hasMinutes}
             isWholeHourStartTime={isWholeHourStartTime}
           />
         );

--- a/src/features/DisplayControls/DrugChart/components/CalendarRow.jsx
+++ b/src/features/DisplayControls/DrugChart/components/CalendarRow.jsx
@@ -5,16 +5,14 @@ import { areDatesSame, formatDate } from "../../../../utils/DateTimeUtils.js";
 import { IPDContext } from "../../../../context/IPDContext";
 import { timeFormatFor12Hr, timeFormatFor24Hr } from "../../../../constants";
 import moment from "moment";
-import { currentShiftHoursArray } from "../utils/DrugChartUtils";
 
 export default function CalendarRow(props) {
   const { config } = useContext(IPDContext);
   const { enable24HourTime = {}, shiftDetails: shiftConfig = {} } = config;
-  const { rowData, currentShiftArray, selectedDate } = props;
+  const { rowData, currentShiftArray, selectedDate, shiftIndex } = props;
   const { slots } = rowData;
   const transformedData = {};
   const currentShiftMinute = currentShiftArray[0].split(":")[1];
-  const { shiftIndex } = currentShiftHoursArray(new Date(), shiftConfig);
   const shiftArray = Object.values(shiftConfig);
   const shiftEndTime = shiftArray[shiftIndex].shiftEndTime;
   const endTime = moment(shiftEndTime, "HH:mm");
@@ -90,7 +88,8 @@ export default function CalendarRow(props) {
               doHighlightCell={isCurrentHour}
               highlightedCell={highlightedCell}
               isBlank={
-                index === currentShiftArray.length - 1 && !isWholeHourEndTime
+                index === currentShiftArray.length - 1 &&
+                !!(isWholeHourEndTime ^ isWholeHourStartTime)
               }
               isWholeHourStartTime={isWholeHourStartTime}
             />
@@ -102,7 +101,8 @@ export default function CalendarRow(props) {
             doHighlightCell={isCurrentHour}
             highlightedCell={highlightedCell}
             isBlank={
-              index === currentShiftArray.length - 1 && !isWholeHourEndTime
+              index === currentShiftArray.length - 1 &&
+              !!(isWholeHourEndTime ^ isWholeHourStartTime)
             }
             isWholeHourStartTime={isWholeHourStartTime}
           />
@@ -116,4 +116,5 @@ CalendarRow.propTypes = {
   rowData: PropTypes.object.isRequired,
   currentShiftArray: PropTypes.array,
   selectedDate: PropTypes.instanceOf(Date),
+  shiftIndex: PropTypes.number,
 };

--- a/src/features/DisplayControls/DrugChart/components/CalendarRow.jsx
+++ b/src/features/DisplayControls/DrugChart/components/CalendarRow.jsx
@@ -5,14 +5,21 @@ import { areDatesSame, formatDate } from "../../../../utils/DateTimeUtils.js";
 import { IPDContext } from "../../../../context/IPDContext";
 import { timeFormatFor12Hr, timeFormatFor24Hr } from "../../../../constants";
 import moment from "moment";
+import { currentShiftHoursArray } from "../utils/DrugChartUtils";
 
 export default function CalendarRow(props) {
   const { config } = useContext(IPDContext);
-  const { enable24HourTime = {} } = config;
+  const { enable24HourTime = {}, shiftDetails: shiftConfig = {} } = config;
   const { rowData, currentShiftArray, selectedDate } = props;
   const { slots } = rowData;
   const transformedData = {};
   const currentShiftMinute = currentShiftArray[0].split(":")[1];
+  const { shiftIndex } = currentShiftHoursArray(new Date(), shiftConfig);
+  const shiftArray = Object.values(shiftConfig);
+  const shiftEndTime = shiftArray[shiftIndex].shiftEndTime;
+  const endTime = moment(shiftEndTime, "HH:mm");
+  const isWholeHourEndTime = endTime.minutes() === 0;
+  const isWholeHourStartTime = Number(currentShiftMinute) === 0;
   slots.forEach((slot) => {
     let time;
     const { medicationAdministration, administrationSummary } = slot;
@@ -82,6 +89,10 @@ export default function CalendarRow(props) {
               key={time}
               doHighlightCell={isCurrentHour}
               highlightedCell={highlightedCell}
+              isBlank={
+                index === currentShiftArray.length - 1 && !isWholeHourEndTime
+              }
+              isWholeHourStartTime={isWholeHourStartTime}
             />
           );
         }
@@ -90,6 +101,10 @@ export default function CalendarRow(props) {
             key={time}
             doHighlightCell={isCurrentHour}
             highlightedCell={highlightedCell}
+            isBlank={
+              index === currentShiftArray.length - 1 && !isWholeHourEndTime
+            }
+            isWholeHourStartTime={isWholeHourStartTime}
           />
         );
       })}

--- a/src/features/DisplayControls/DrugChart/components/DrugChart.jsx
+++ b/src/features/DisplayControls/DrugChart/components/DrugChart.jsx
@@ -11,7 +11,7 @@ import { ChevronDown20, ChevronUp20 } from "@carbon/icons-react";
 import { throttle } from "lodash";
 
 export default function DrugChart(props) {
-  const { drugChartData, currentShiftArray, selectedDate } = props;
+  const { drugChartData, currentShiftArray, selectedDate, shiftIndex } = props;
   const leftPane = useRef(null);
   const rightPane = useRef(null);
   const [isPrevDisabled, setIsPrevDisabled] = useState(true);
@@ -131,6 +131,7 @@ export default function DrugChart(props) {
             calendarData={drugChartData}
             currentShiftArray={currentShiftArray}
             selectedDate={selectedDate}
+            shiftIndex={shiftIndex}
           />
         </div>
       </div>
@@ -151,4 +152,5 @@ DrugChart.propTypes = {
   drugChartData: PropTypes.array.isRequired,
   currentShiftArray: PropTypes.array,
   selectedDate: PropTypes.instanceOf(Date),
+  shiftIndex: PropTypes.number,
 };

--- a/src/features/DisplayControls/DrugChart/components/DrugChartView.jsx
+++ b/src/features/DisplayControls/DrugChart/components/DrugChartView.jsx
@@ -310,6 +310,7 @@ export default function DrugChartWrapper(props) {
           drugChartData={transformedData}
           currentShiftArray={currentShiftArray}
           selectedDate={startEndDates.startDate}
+          shiftIndex={shiftIndex}
         />
       )}
     </div>

--- a/src/features/DisplayControls/DrugChart/components/TimeCell.jsx
+++ b/src/features/DisplayControls/DrugChart/components/TimeCell.jsx
@@ -77,32 +77,34 @@ export default function TimeCell(props) {
           );
         })}
       </div>
-      <div
-        data-testid="right-icon"
-        className={
-          doHighlightCell && highlightedCell === "right"
-            ? "highlightedCell"
-            : isBlank
-            ? "blank"
-            : ""
-        }
-      >
-        {right.map((slot) => {
-          const { status, administrationInfo, notes, minutes } = slot;
-          return (
-            <div key={minutes}>
-              <SVGIcon iconType={status} info={administrationInfo} />
-              {ifMedicationNotesPresent(notes, status) && (
-                <span data-testid="right-notes">
-                  <Tooltip autoOrientation={true} renderIcon={() => icon}>
-                    {notes}
-                  </Tooltip>
-                </span>
-              )}
-            </div>
-          );
-        })}
-      </div>
+      {!isBlank ? (
+        <div
+          data-testid="right-icon"
+          className={
+            doHighlightCell && highlightedCell === "right"
+              ? "highlightedCell"
+              : ""
+          }
+        >
+          {right.map((slot) => {
+            const { status, administrationInfo, notes, minutes } = slot;
+            return (
+              <div key={minutes}>
+                <SVGIcon iconType={status} info={administrationInfo} />
+                {ifMedicationNotesPresent(notes, status) && (
+                  <span data-testid="right-notes">
+                    <Tooltip autoOrientation={true} renderIcon={() => icon}>
+                      {notes}
+                    </Tooltip>
+                  </span>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ) : (
+        <div className="blank"></div>
+      )}
     </div>
   );
 }

--- a/src/features/DisplayControls/DrugChart/components/TimeCell.jsx
+++ b/src/features/DisplayControls/DrugChart/components/TimeCell.jsx
@@ -15,6 +15,8 @@ export default function TimeCell(props) {
     endTime = "",
     doHighlightCell,
     highlightedCell,
+    isBlank,
+    isWholeHourStartTime,
   } = props;
   const left = [],
     right = [];
@@ -46,11 +48,17 @@ export default function TimeCell(props) {
   );
 
   return (
-    <div className="time-cell">
+    <div
+      className={
+        isWholeHourStartTime
+          ? "time-cell-for-whole-hour"
+          : "time-cell-for-half-hour"
+      }
+    >
       <div
         data-testid="left-icon"
         className={
-          doHighlightCell && highlightedCell === "left" ? "highligtedCell" : ""
+          doHighlightCell && highlightedCell === "left" ? "highlightedCell" : ""
         }
       >
         {left.map((slot) => {
@@ -72,7 +80,11 @@ export default function TimeCell(props) {
       <div
         data-testid="right-icon"
         className={
-          doHighlightCell && highlightedCell === "right" ? "highligtedCell" : ""
+          doHighlightCell && highlightedCell === "right"
+            ? "highlightedCell"
+            : isBlank
+            ? "blank"
+            : ""
         }
       >
         {right.map((slot) => {
@@ -101,4 +113,6 @@ TimeCell.propTypes = {
   highlightedCell: PropTypes.string,
   startTime: PropTypes.object,
   endTime: PropTypes.object,
+  isBlank: PropTypes.bool,
+  isWholeHourStartTime: PropTypes.bool,
 };

--- a/src/features/DisplayControls/DrugChart/styles/CalendarHeader.scss
+++ b/src/features/DisplayControls/DrugChart/styles/CalendarHeader.scss
@@ -11,7 +11,7 @@
   --border-widths: calc(
     calc(1 + var(--additional-borders)) * var(--line-width)
   );
-  --width: calc(calc(2 * var(--half-hour-width)) + var(--border-widths));
+  --width: calc(var(--half-hour-width) + var(--border-widths));
   width: var(--width);
   height: 63px;
   color: var(--gray-gray-80, #393939);
@@ -23,6 +23,14 @@
   display: grid;
   align-items: end;
   box-sizing: border-box;
+
+  &:first-child {
+    --additional-borders: 1;
+  }
+
+  &:nth-child(2n) {
+    --width: calc(var(--half-hour-width));
+  }
 
   &:last-child {
     --additional-borders: 1;

--- a/src/features/DisplayControls/DrugChart/styles/TimeCell.scss
+++ b/src/features/DisplayControls/DrugChart/styles/TimeCell.scss
@@ -1,7 +1,4 @@
 .time-cell {
-  --day-border: 1px solid #c6c6c6;
-  box-sizing: content-box;
-  border-left: var(--day-border);
   display: flex;
   height: var(--time-cell-height);
   align-items: stretch;
@@ -10,7 +7,7 @@
   }
 
   &:first-child {
-    border-left: 2px solid #c6c6c6;
+    border-left: var(--day-border-2);
   }
 
   &:last-child {
@@ -28,7 +25,7 @@
     padding: 25px 0;
     text-align: center;
     &:last-child {
-      border-left: 1px dashed #c6c6c6;
+      border-left: var(--half-day-border);
     }
   }
   svg {
@@ -43,7 +40,27 @@
     }
   }
 
-  .highligtedCell {
+  .highlightedCell {
     background-color: #e3f1fa;
   }
+
+  .blank {
+    background-color: white;
+  }
+}
+
+.time-cell-for-whole-hour {
+  --day-border: 1px solid #c6c6c6;
+  --day-border-2: 2px solid #c6c6c6;
+  --half-day-border: 1px dashed #c6c6c6;
+  border-left: var(--day-border);
+  @extend .time-cell;
+}
+
+.time-cell-for-half-hour {
+  --day-border: 1px dashed #c6c6c6;
+  --day-border-2: 1px dashed #c6c6c6;
+  --half-day-border: 1px solid #c6c6c6;
+  border-left: var(--day-border);
+  @extend .time-cell;
 }

--- a/src/features/DisplayControls/DrugChart/tests/CalendarHeader.spec.jsx
+++ b/src/features/DisplayControls/DrugChart/tests/CalendarHeader.spec.jsx
@@ -60,7 +60,7 @@ describe("CalendarHeader", () => {
       </IPDContext.Provider>
     );
     const hours = getAllByTestId("hour");
-    expect(hours.length).toBe(
+    expect(hours.length / 2).toBe(
       currentShiftHoursArray(new Date(), shiftDetails).currentShiftHoursArray
         .length
     );
@@ -93,7 +93,7 @@ describe("CalendarHeader", () => {
       </IPDContext.Provider>
     );
     const hours = getAllByTestId("hour");
-    expect(hours.length).toBe(
+    expect(hours.length / 2).toBe(
       currentShiftHoursArray(new Date(), shiftDetails).currentShiftHoursArray
         .length
     );

--- a/src/features/DisplayControls/DrugChart/tests/CalendarRow.spec.jsx
+++ b/src/features/DisplayControls/DrugChart/tests/CalendarRow.spec.jsx
@@ -1,7 +1,11 @@
 import React from "react";
 import { render } from "@testing-library/react";
 import CalendarRow from "../components/CalendarRow";
-import { calendarRowData, currentShiftArray } from "./CalendarRowMockData";
+import {
+  calendarRowData,
+  currentShiftArray,
+  currentShiftArrayWithHalfHour,
+} from "./CalendarRowMockData";
 import MockDate from "mockdate";
 import { mockConfig } from "../../../../utils/CommonUtils";
 import { IPDContext } from "../../../../context/IPDContext";
@@ -25,10 +29,104 @@ describe("CalendarRow", () => {
         <CalendarRow
           rowData={calendarRowData}
           currentShiftArray={currentShiftArray}
+          shiftIndex={0}
         />
       </IPDContext.Provider>
     );
     expect(mockTimeCell).toHaveBeenCalled();
+    MockDate.reset();
+  });
+
+  it("should return mock timeCell with isblank prop as true when both shiftStartTime and shiftEndTime is not wholeHour or half-hour", () => {
+    MockDate.set("2023-12-22T08:00:00.000+0530");
+    render(
+      <IPDContext.Provider
+        value={{
+          config: {
+            ...mockConfig,
+            shiftDetails: {
+              1: { shiftStartTime: "08:00", shiftEndTime: "19:30" },
+              2: { shiftStartTime: "19:30", shiftEndTime: "08:00" },
+            },
+          },
+        }}
+      >
+        <CalendarRow
+          rowData={calendarRowData}
+          currentShiftArray={currentShiftArray}
+          shiftIndex={0}
+        />
+      </IPDContext.Provider>
+    );
+    expect(mockTimeCell).toHaveBeenCalledTimes(8);
+    expect(mockTimeCell).toHaveBeenLastCalledWith({
+      doHighlightCell: false,
+      highlightedCell: "left",
+      isBlank: true,
+      isWholeHourStartTime: true,
+    });
+    MockDate.reset();
+  });
+
+  it("should return mock timeCell with isblank prop as false when both shiftStartTime and shiftEndTime is wholeHour", () => {
+    MockDate.set("2023-12-22T08:00:00.000+0530");
+    render(
+      <IPDContext.Provider
+        value={{
+          config: {
+            ...mockConfig,
+            shiftDetails: {
+              1: { shiftStartTime: "08:00", shiftEndTime: "19:00" },
+              2: { shiftStartTime: "19:00", shiftEndTime: "08:00" },
+            },
+          },
+        }}
+      >
+        <CalendarRow
+          rowData={calendarRowData}
+          currentShiftArray={currentShiftArray}
+          shiftIndex={0}
+        />
+      </IPDContext.Provider>
+    );
+    expect(mockTimeCell).toHaveBeenCalledTimes(8);
+    expect(mockTimeCell).toHaveBeenLastCalledWith({
+      doHighlightCell: false,
+      highlightedCell: "left",
+      isBlank: false,
+      isWholeHourStartTime: true,
+    });
+    MockDate.reset();
+  });
+
+  it("should return mock timeCell with isblank prop as false when both shiftStartTime and shiftEndTime is half-hour", () => {
+    MockDate.set("2023-12-22T08:00:00.000+0530");
+    render(
+      <IPDContext.Provider
+        value={{
+          config: {
+            ...mockConfig,
+            shiftDetails: {
+              1: { shiftStartTime: "08:30", shiftEndTime: "19:30" },
+              2: { shiftStartTime: "19:30", shiftEndTime: "08:30" },
+            },
+          },
+        }}
+      >
+        <CalendarRow
+          rowData={calendarRowData}
+          currentShiftArray={currentShiftArrayWithHalfHour}
+          shiftIndex={0}
+        />
+      </IPDContext.Provider>
+    );
+    expect(mockTimeCell).toHaveBeenCalledTimes(8);
+    expect(mockTimeCell).toHaveBeenLastCalledWith({
+      doHighlightCell: false,
+      highlightedCell: "left",
+      isBlank: false,
+      isWholeHourStartTime: false,
+    });
     MockDate.reset();
   });
 });

--- a/src/features/DisplayControls/DrugChart/tests/CalendarRowMockData.js
+++ b/src/features/DisplayControls/DrugChart/tests/CalendarRowMockData.js
@@ -291,3 +291,14 @@ export const currentShiftArray = [
   "20:00",
   "21:00",
 ];
+
+export const currentShiftArrayWithHalfHour = [
+  "14:30",
+  "15:30",
+  "16:30",
+  "17:30",
+  "18:30",
+  "19:30",
+  "20:30",
+  "21:30",
+];

--- a/src/features/DisplayControls/DrugChart/tests/TimeCell.spec.jsx
+++ b/src/features/DisplayControls/DrugChart/tests/TimeCell.spec.jsx
@@ -128,9 +128,9 @@ describe("TimeCell", () => {
       />
     );
 
-    expect(component.getByTestId("left-icon")).toHaveClass("highligtedCell");
+    expect(component.getByTestId("left-icon")).toHaveClass("highlightedCell");
     expect(component.getByTestId("right-icon")).not.toHaveClass(
-      "highligtedCell"
+      "highlightedCell"
     );
   });
 
@@ -148,9 +148,9 @@ describe("TimeCell", () => {
     );
 
     expect(component.getByTestId("left-icon")).not.toHaveClass(
-      "highligtedCell"
+      "highlightedCell"
     );
-    expect(component.getByTestId("right-icon")).toHaveClass("highligtedCell");
+    expect(component.getByTestId("right-icon")).toHaveClass("highlightedCell");
   });
 
   it("should not highlight if highligted flag cell is false", () => {
@@ -167,10 +167,10 @@ describe("TimeCell", () => {
     );
 
     expect(component.getByTestId("left-icon")).not.toHaveClass(
-      "highligtedCell"
+      "highlightedCell"
     );
     expect(component.getByTestId("right-icon")).not.toHaveClass(
-      "highligtedCell"
+      "highlightedCell"
     );
   });
 });

--- a/src/features/DisplayControls/DrugChart/tests/__snapshots__/CalendarHeader.spec.jsx.snap
+++ b/src/features/DisplayControls/DrugChart/tests/__snapshots__/CalendarHeader.spec.jsx.snap
@@ -18,7 +18,19 @@ exports[`CalendarHeader should match snapshot 1`] = `
         class="hour-header"
         data-testid="hour"
       >
+        06:30
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
         07:00
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
+        07:30
       </div>
       <div
         class="hour-header"
@@ -30,7 +42,19 @@ exports[`CalendarHeader should match snapshot 1`] = `
         class="hour-header"
         data-testid="hour"
       >
+        08:30
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
         09:00
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
+        09:30
       </div>
       <div
         class="hour-header"
@@ -42,7 +66,19 @@ exports[`CalendarHeader should match snapshot 1`] = `
         class="hour-header"
         data-testid="hour"
       >
+        10:30
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
         11:00
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
+        11:30
       </div>
       <div
         class="hour-header"
@@ -54,7 +90,19 @@ exports[`CalendarHeader should match snapshot 1`] = `
         class="hour-header"
         data-testid="hour"
       >
+        12:30
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
         13:00
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
+        13:30
       </div>
       <div
         class="hour-header"
@@ -66,7 +114,19 @@ exports[`CalendarHeader should match snapshot 1`] = `
         class="hour-header"
         data-testid="hour"
       >
+        14:30
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
         15:00
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
+        15:30
       </div>
       <div
         class="hour-header"
@@ -78,7 +138,19 @@ exports[`CalendarHeader should match snapshot 1`] = `
         class="hour-header"
         data-testid="hour"
       >
+        16:30
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
         17:00
+      </div>
+      <div
+        class="hour-header"
+        data-testid="hour"
+      >
+        17:30
       </div>
     </div>
   </div>

--- a/src/features/DisplayControls/DrugChart/tests/__snapshots__/DrugChartView.spec.jsx.snap
+++ b/src/features/DisplayControls/DrugChart/tests/__snapshots__/DrugChartView.spec.jsx.snap
@@ -258,7 +258,19 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                 class="hour-header"
                 data-testid="hour"
               >
+                06:30
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
                 07:00
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
+                07:30
               </div>
               <div
                 class="hour-header"
@@ -270,7 +282,19 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                 class="hour-header"
                 data-testid="hour"
               >
+                08:30
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
                 09:00
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
+                09:30
               </div>
               <div
                 class="hour-header"
@@ -282,7 +306,19 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                 class="hour-header"
                 data-testid="hour"
               >
+                10:30
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
                 11:00
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
+                11:30
               </div>
               <div
                 class="hour-header"
@@ -294,7 +330,19 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                 class="hour-header"
                 data-testid="hour"
               >
+                12:30
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
                 13:00
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
+                13:30
               </div>
               <div
                 class="hour-header"
@@ -306,7 +354,19 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                 class="hour-header"
                 data-testid="hour"
               >
+                14:30
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
                 15:00
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
+                15:30
               </div>
               <div
                 class="hour-header"
@@ -318,7 +378,19 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                 class="hour-header"
                 data-testid="hour"
               >
+                16:30
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
                 17:00
+              </div>
+              <div
+                class="hour-header"
+                data-testid="hour"
+              >
+                17:30
               </div>
             </div>
           </div>
@@ -331,7 +403,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                   style="display: flex;"
                 >
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -343,7 +415,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -355,7 +427,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -367,7 +439,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -379,7 +451,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -391,7 +463,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -403,7 +475,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -415,7 +487,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -427,7 +499,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -439,7 +511,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -451,7 +523,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""
@@ -463,7 +535,7 @@ exports[`DrugChartWrapper matches snapshot 1`] = `
                     />
                   </div>
                   <div
-                    class="time-cell"
+                    class="time-cell-for-whole-hour"
                   >
                     <div
                       class=""

--- a/src/utils/DateTimeUtils.js
+++ b/src/utils/DateTimeUtils.js
@@ -108,6 +108,12 @@ export const isTimeInFuture = (time1, time2) => {
   return time1_24hr > time2_24hr;
 };
 
+export const add30Minutes = (timeStr) => {
+  const originalTime = moment(timeStr, "HH:mm");
+  const incrementedTime = originalTime.clone().add(30, "minutes");
+  return [originalTime.format("HH:mm"), incrementedTime.format("HH:mm")];
+};
+
 export const getFormattedDateTime = (
   hours,
   minutes,


### PR DESCRIPTION
A - https://app.asana.com/0/1204322126657135/1207130872445771/f

→ When shift starts at hrs like 7:30, and ends at hrs like 20:00, then the last column (20:00-20:30) should be marked differently - 
→ Half hr time (like 7:30) should be denoted in dotted line and full hr time (like 8:00) should be denoted in solid line - 
→ All the hrs (irrespective of half hr or full hr time) should have time mentioned on top, in the right side panel of the Drug Chart 