### PR TITLE
BAH-3980 | Refactor. Remove task type check for system generated task by task_type and use creator

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -149,3 +149,7 @@ export const GenericErrorMessage = "Technical error";
 export const errorCodes = {
   FORBIDDEN: 403,
 };
+export const DAEMON_USER = {
+  "name": "daemon",
+  "uuid": "A4F30A1B-5EB9-11DF-A648-37A07F9C90FB"
+}

--- a/src/features/CareViewPatientsSummary/components/CareViewPatientsSummary.jsx
+++ b/src/features/CareViewPatientsSummary/components/CareViewPatientsSummary.jsx
@@ -11,6 +11,7 @@ import { SlotDetailsCell } from "./SlotDetailsCell";
 import { Header } from "./Header";
 import { getPreviousShiftDetails } from "../../CareViewSummary/utils/CareViewSummary";
 import { currentShiftHoursArray, setCurrentShiftTimes } from "../../DisplayControls/DrugChart/utils/DrugChartUtils";
+import { isSystemGeneratedTask } from "../../../utils/CommonUtils";
 
 export const CareViewPatientsSummary = ({
   patientsSummary,
@@ -73,7 +74,7 @@ export const CareViewPatientsSummary = ({
     const patientUuid = patientData.patientUuid;
     const patientTasks = [];
     patientData.tasks.forEach(task => {
-      if (task.taskType?.display === "nursing_activity_system" && task.status === "REQUESTED") {
+      if (isSystemGeneratedTask(task) && task.status === "REQUESTED") {
         
           patientTasks.push({
               taskName: task.name,

--- a/src/features/DisplayControls/NursingTasks/components/TaskTile.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/TaskTile.jsx
@@ -16,6 +16,7 @@ import {
   timeFormatFor12Hr,
   timeFormatFor24Hr,
 } from "../../../../constants";
+import { isSystemGeneratedTask } from "../../../../utils/CommonUtils";
 
 export default function TaskTile(props) {
   const { medicationNursingTask } = props;
@@ -51,8 +52,6 @@ export default function TaskTile(props) {
     startTimeInEpochSeconds,
     nursingTasks
   );
-
-  const isSystemGeneratedTask = taskType?.display === "nursing_activity_system";
 
   const creatorName = (creator) => {
     var formattedName = creator.split(".").join(" ");
@@ -120,7 +119,7 @@ export default function TaskTile(props) {
             }}
           >
             <span>{dosage}</span>
-            {creator && !isSystemGeneratedTask && (
+            {creator && !isSystemGeneratedTask(newMedicationNursingTask) && (
               <span style={{ textTransform: "capitalize" }}>
                 {creatorName(creator.display)}
               </span>

--- a/src/features/DisplayControls/NursingTasks/components/UpdateNursingTasks.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/UpdateNursingTasks.jsx
@@ -167,7 +167,7 @@ const UpdateNursingTasks = (props) => {
   useEffect(() => {
     medicationTasks.map((medicationTask) => {
       updateIsPRNMedication(medicationTask?.dosingInstructions?.asNeeded);
-      updateIsNonMedication(medicationTask?.taskType?.display);
+      updateIsNonMedication(medicationTask?.isANonMedicationTask);
       updateIsSystemGeneratedNonMedication(
         isSystemGeneratedTask(medicationTask)
       );

--- a/src/features/DisplayControls/NursingTasks/components/UpdateNursingTasks.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/UpdateNursingTasks.jsx
@@ -37,6 +37,7 @@ import {
   formatTime,
   isTimeInFuture,
 } from "../../../../utils/DateTimeUtils";
+import { isSystemGeneratedTask } from "../../../../utils/CommonUtils";
 
 const UpdateNursingTasks = (props) => {
   const {
@@ -168,7 +169,7 @@ const UpdateNursingTasks = (props) => {
       updateIsPRNMedication(medicationTask?.dosingInstructions?.asNeeded);
       updateIsNonMedication(medicationTask?.taskType?.display);
       updateIsSystemGeneratedNonMedication(
-        medicationTask?.taskType?.display == "nursing_activity_system"
+        isSystemGeneratedTask(medicationTask)
       );
       updateTasks((prev) => {
         return {

--- a/src/utils/CommonUtils.jsx
+++ b/src/utils/CommonUtils.jsx
@@ -7,6 +7,7 @@ import {
   FORM_BASE_URL,
   SEARCH_CONCEPT_URL,
   SEARCH_DRUG_URL,
+  DAEMON_USER,
 } from "../constants";
 import { FormattedMessage } from "react-intl";
 export const getPatientDashboardUrl = (patientUuid) =>
@@ -355,3 +356,7 @@ export const mockConfigFor12HourFormat = {
     2: { shiftStartTime: "19:00", shiftEndTime: "08:00" },
   },
 };
+
+export const isSystemGeneratedTask =(task)=>{
+  return task?.creator?.uuid === DAEMON_USER.uuid || task?.creator?.name === DAEMON_USER.name; 
+}


### PR DESCRIPTION
This PR removes the hardcoding of `nursing_activity_system` for the task type which is used to determine whether a task is system generated or manual task. 

Now, instead of that the creator attribute of the task is used to identify whether a task is system generated task. The check happens by [Daemon User UUID](https://github.com/openmrs/openmrs-core/blob/master/api/src/main/java/org/openmrs/api/context/Daemon.java#L44) or [name](https://github.com/openmrs/openmrs-core/blob/2df2e48066fd903c4bf48ca34b935e0435370ce1/api/src/main/resources/org/openmrs/liquibase/snapshots/core-data/liquibase-core-data-2.5.x.xml#L63).