### PR TITLE
BAH-4034 | Add. Support For Config Driven Non Medication Task Type

### DIFF
--- a/src/features/CareViewPatientsSummary/components/CareViewPatientsSummary.jsx
+++ b/src/features/CareViewPatientsSummary/components/CareViewPatientsSummary.jsx
@@ -10,7 +10,10 @@ import { PatientDetailsCell } from "./PatientDetailsCell";
 import { SlotDetailsCell } from "./SlotDetailsCell";
 import { Header } from "./Header";
 import { getPreviousShiftDetails } from "../../CareViewSummary/utils/CareViewSummary";
-import { currentShiftHoursArray, setCurrentShiftTimes } from "../../DisplayControls/DrugChart/utils/DrugChartUtils";
+import {
+  currentShiftHoursArray,
+  setCurrentShiftTimes,
+} from "../../DisplayControls/DrugChart/utils/DrugChartUtils";
 import { isSystemGeneratedTask } from "../../../utils/CommonUtils";
 
 export const CareViewPatientsSummary = ({
@@ -20,17 +23,16 @@ export const CareViewPatientsSummary = ({
 }) => {
   const [slotDetails, setSlotDetails] = useState([]);
   const [nonMedicationDetails, setNonMedicationDetails] = useState([]);
-  const [previousShiftNonMedicationDetails, setPreviousShiftNonMedicationDetails] = useState([]);
+  const [
+    previousShiftNonMedicationDetails,
+    setPreviousShiftNonMedicationDetails,
+  ] = useState([]);
   const { careViewConfig, ipdConfig } = useContext(CareViewContext);
   const { shiftDetails: shiftConfig = {} } = ipdConfig;
   const timeframeLimitInHours = careViewConfig.timeframeLimitInHours;
-  const shiftDetails = currentShiftHoursArray(
-    new Date(),
-    shiftConfig
-  );
+  const shiftDetails = currentShiftHoursArray(new Date(), shiftConfig);
   const shiftRangeArray = shiftDetails.rangeArray;
   const shiftIndex = shiftDetails.shiftIndex;
- 
 
   const fetchSlots = async (patients) => {
     const patientUuids = patients.map((patient) => patient.patientDetails.uuid);
@@ -53,11 +55,8 @@ export const CareViewPatientsSummary = ({
   };
 
   const fetchPreviousShiftTasks = async (patients) => {
-    const [startDateTime, endDateTime] =  setCurrentShiftTimes(
-      shiftDetails
-    );
-    const previousShiftDetails =
-    getPreviousShiftDetails(
+    const [startDateTime, endDateTime] = setCurrentShiftTimes(shiftDetails);
+    const previousShiftDetails = getPreviousShiftDetails(
       shiftRangeArray,
       shiftIndex,
       startDateTime,
@@ -66,31 +65,30 @@ export const CareViewPatientsSummary = ({
     const patientUuids = patients.map((patient) => patient.patientDetails.uuid);
     const response = await getTasksForPatients(
       patientUuids,
-      previousShiftDetails.startDateTime ,
-      previousShiftDetails.endDateTime 
+      previousShiftDetails.startDateTime,
+      previousShiftDetails.endDateTime
     );
     const groupedData = [];
-    response.forEach(patientData => {
-    const patientUuid = patientData.patientUuid;
-    const patientTasks = [];
-    patientData.tasks.forEach(task => {
-      if (isSystemGeneratedTask(task) && task.status === "REQUESTED") {
-        
+    response.forEach((patientData) => {
+      const patientUuid = patientData.patientUuid;
+      const patientTasks = [];
+      patientData.tasks.forEach((task) => {
+        if (isSystemGeneratedTask(task) && task.status === "REQUESTED") {
           patientTasks.push({
-              taskName: task.name,
-              taskId: task.uuid 
+            taskName: task.name,
+            taskId: task.uuid,
           });
-      }
+        }
+      });
+      groupedData.push({
+        patient: patientUuid,
+        tasks: patientTasks,
+      });
     });
-    groupedData.push({
-      patient: patientUuid,
-      tasks: patientTasks
-    });
-  });
     setPreviousShiftNonMedicationDetails(groupedData);
-  }
- 
-  useEffect(() => { 
+  };
+
+  useEffect(() => {
     if (patientsSummary.length > 0) {
       fetchPreviousShiftTasks(patientsSummary);
       fetchSlots(patientsSummary);
@@ -112,10 +110,12 @@ export const CareViewPatientsSummary = ({
               bedDetails,
               careTeam,
               newTreatments,
-              visitDetails
+              visitDetails,
             } = patientSummary;
             const { uuid } = patientDetails;
-            const matchingShift = previousShiftNonMedicationDetails.find(shift => shift.patient === uuid);
+            const matchingShift = previousShiftNonMedicationDetails.find(
+              (shift) => shift.patient === uuid
+            );
             const tasks = matchingShift ? matchingShift.tasks : [];
             return (
               <tr key={idx} className={"patient-row-container"}>

--- a/src/features/CareViewPatientsSummary/components/CareViewPatientsSummary.jsx
+++ b/src/features/CareViewPatientsSummary/components/CareViewPatientsSummary.jsx
@@ -10,10 +10,7 @@ import { PatientDetailsCell } from "./PatientDetailsCell";
 import { SlotDetailsCell } from "./SlotDetailsCell";
 import { Header } from "./Header";
 import { getPreviousShiftDetails } from "../../CareViewSummary/utils/CareViewSummary";
-import {
-  currentShiftHoursArray,
-  setCurrentShiftTimes,
-} from "../../DisplayControls/DrugChart/utils/DrugChartUtils";
+import { currentShiftHoursArray, setCurrentShiftTimes } from "../../DisplayControls/DrugChart/utils/DrugChartUtils";
 import { isSystemGeneratedTask } from "../../../utils/CommonUtils";
 
 export const CareViewPatientsSummary = ({
@@ -23,16 +20,17 @@ export const CareViewPatientsSummary = ({
 }) => {
   const [slotDetails, setSlotDetails] = useState([]);
   const [nonMedicationDetails, setNonMedicationDetails] = useState([]);
-  const [
-    previousShiftNonMedicationDetails,
-    setPreviousShiftNonMedicationDetails,
-  ] = useState([]);
+  const [previousShiftNonMedicationDetails, setPreviousShiftNonMedicationDetails] = useState([]);
   const { careViewConfig, ipdConfig } = useContext(CareViewContext);
   const { shiftDetails: shiftConfig = {} } = ipdConfig;
   const timeframeLimitInHours = careViewConfig.timeframeLimitInHours;
-  const shiftDetails = currentShiftHoursArray(new Date(), shiftConfig);
+  const shiftDetails = currentShiftHoursArray(
+    new Date(),
+    shiftConfig
+  );
   const shiftRangeArray = shiftDetails.rangeArray;
   const shiftIndex = shiftDetails.shiftIndex;
+ 
 
   const fetchSlots = async (patients) => {
     const patientUuids = patients.map((patient) => patient.patientDetails.uuid);
@@ -55,8 +53,11 @@ export const CareViewPatientsSummary = ({
   };
 
   const fetchPreviousShiftTasks = async (patients) => {
-    const [startDateTime, endDateTime] = setCurrentShiftTimes(shiftDetails);
-    const previousShiftDetails = getPreviousShiftDetails(
+    const [startDateTime, endDateTime] =  setCurrentShiftTimes(
+      shiftDetails
+    );
+    const previousShiftDetails =
+    getPreviousShiftDetails(
       shiftRangeArray,
       shiftIndex,
       startDateTime,
@@ -65,30 +66,31 @@ export const CareViewPatientsSummary = ({
     const patientUuids = patients.map((patient) => patient.patientDetails.uuid);
     const response = await getTasksForPatients(
       patientUuids,
-      previousShiftDetails.startDateTime,
-      previousShiftDetails.endDateTime
+      previousShiftDetails.startDateTime ,
+      previousShiftDetails.endDateTime 
     );
     const groupedData = [];
-    response.forEach((patientData) => {
-      const patientUuid = patientData.patientUuid;
-      const patientTasks = [];
-      patientData.tasks.forEach((task) => {
-        if (isSystemGeneratedTask(task) && task.status === "REQUESTED") {
+    response.forEach(patientData => {
+    const patientUuid = patientData.patientUuid;
+    const patientTasks = [];
+    patientData.tasks.forEach(task => {
+      if (isSystemGeneratedTask(task) && task.status === "REQUESTED") {
+        
           patientTasks.push({
-            taskName: task.name,
-            taskId: task.uuid,
+              taskName: task.name,
+              taskId: task.uuid 
           });
-        }
-      });
-      groupedData.push({
-        patient: patientUuid,
-        tasks: patientTasks,
-      });
+      }
     });
+    groupedData.push({
+      patient: patientUuid,
+      tasks: patientTasks
+    });
+  });
     setPreviousShiftNonMedicationDetails(groupedData);
-  };
-
-  useEffect(() => {
+  }
+ 
+  useEffect(() => { 
     if (patientsSummary.length > 0) {
       fetchPreviousShiftTasks(patientsSummary);
       fetchSlots(patientsSummary);
@@ -110,12 +112,10 @@ export const CareViewPatientsSummary = ({
               bedDetails,
               careTeam,
               newTreatments,
-              visitDetails,
+              visitDetails
             } = patientSummary;
             const { uuid } = patientDetails;
-            const matchingShift = previousShiftNonMedicationDetails.find(
-              (shift) => shift.patient === uuid
-            );
+            const matchingShift = previousShiftNonMedicationDetails.find(shift => shift.patient === uuid);
             const tasks = matchingShift ? matchingShift.tasks : [];
             return (
               <tr key={idx} className={"patient-row-container"}>

--- a/src/features/CareViewSummary/tests/CareViewSummaryMock.js
+++ b/src/features/CareViewSummary/tests/CareViewSummaryMock.js
@@ -39,7 +39,7 @@ export const mockNonMedicationData = [
         partOf: null,
         taskType: {
           uuid: "91e3eeba-e840-11ee-b597-0242ac120005",
-          display: "nursing_activity",
+          display: "Non Medication Task",
         },
         creator: {
           uuid: "c1c21e11-3f10-11e4-adec-0800271c1b75",
@@ -57,7 +57,7 @@ export const mockNonMedicationData = [
         partOf: null,
         taskType: {
           uuid: "91e3eeba-e840-11ee-b597-0242ac120005",
-          display: "nursing_activity",
+          display: "Non Medication Task",
         },
         creator: {
           uuid: "c1c21e11-3f10-11e4-adec-0800271c1b75",
@@ -75,7 +75,7 @@ export const mockNonMedicationData = [
         partOf: null,
         taskType: {
           uuid: "91e3eeba-e840-11ee-b597-0242ac120005",
-          display: "nursing_activity",
+          display: "Non Medication Task",
         },
         creator: {
           uuid: "c1c21e11-3f10-11e4-adec-0800271c1b75",

--- a/src/features/DisplayControls/NursingTasks/components/AddEmergencyTasks.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/AddEmergencyTasks.jsx
@@ -276,7 +276,7 @@ const AddEmergencyTasks = (props) => {
       patientUuid: patientId,
       encounterUuid: encounterUuid.encounterUuid,
       intent: "ORDER",
-      taskType: nonMedicationTaskType,
+      taskType: nonMedicationTaskType ? nonMedicationTaskType : null,
       status: "REQUESTED",
     };
     return nonMedicationPayload;
@@ -329,11 +329,9 @@ const AddEmergencyTasks = (props) => {
   const handleNonMedicationSaveButton = () => {
     if (
       task &&
-      nonMedicationTaskType &&
       scheduleTime &&
       !(
         _.isEmpty(task) ||
-        _.isEmpty(nonMedicationTaskType) ||
         _.isEmpty(scheduleTime)
       )
     ) {
@@ -616,17 +614,20 @@ const AddEmergencyTasks = (props) => {
                   maxCount={10}
                   rows={1}
                 />
-                <Dropdown
-                  id={"non-medication-task-type-dropdown"}
-                  onChange={(selectedItem) => {
-                    setNonMedicationTaskType(selectedItem?.value);
-                  }}
-                  placeholder={"Select Task Type"}
-                  titleText={"Task Type"}
-                  isRequired={true}
-                  options={nonMedicationTaskTypeOptions}
-                  width={"100%"}
-                />
+                { 
+                  (nonMedicationTaskTypeOptions && nonMedicationTaskTypeOptions.length > 0) && 
+                  <Dropdown
+                    id={"non-medication-task-type-dropdown"}
+                    onChange={(selectedItem) => {
+                      setNonMedicationTaskType(selectedItem?.value);
+                    }}
+                    placeholder={"Select Task Type"}
+                    titleText={"Task Type"}
+                    isRequired={false}
+                    options={nonMedicationTaskTypeOptions}
+                    width={"100%"}
+                  />
+                }
                 <div className="time-info">
                   {enable24HourTime ? (
                     <TimePicker24Hour

--- a/src/features/DisplayControls/NursingTasks/components/AddEmergencyTasks.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/AddEmergencyTasks.jsx
@@ -53,15 +53,18 @@ const AddEmergencyTasks = (props) => {
     setShowSuccessNotification,
     setSuccessMessage,
   } = props;
-  const [isSaveDisabled, updateIsSaveDisabled] = useState(true);
+
+  const [isSaveDisabled, setIsSaveDisabled] = useState(true);
   const [isLoading, setIsLoading] = useState(true);
   const [dosageConfig, setDosageConfig] = useState({});
   const [unitOptions, setUnitOptions] = useState([]);
   const [routeOptions, setRouteOptions] = useState([]);
   const [providerOptions, setProviderOptions] = useState([]);
   const [activeTab, setActiveTab] = useState("Medication");
+  const [nonMedicationTaskTypeOptions, setNonMedicationTaskTypeOptions] =
+    useState({});
   const { config = {}, handleAuditEvent } = useContext(IPDContext);
-  const { enable24HourTime = {} } = config;
+  const { enable24HourTime = {}, nonMedicationTaskTypes = [] } = config;
 
   const [selectedDrug, setSelectedDrug] = useState({});
   const [doseUnits, setDoseUnits] = useState({});
@@ -84,6 +87,7 @@ const AddEmergencyTasks = (props) => {
   const [dosage, setDosage] = useState(undefined);
   const [notes, setNotes] = useState("");
   const [task, setTask] = useState("");
+  const [nonMedicationTaskType, setNonMedicationTaskType] = useState();
   const [emergencyTask, setEmergencyTask] = useState({});
   const [popupMedicationData, setPopupMedicationData] = useState({});
   const [showWarningNotification, setShowWarningNotification] = useState(false);
@@ -111,6 +115,20 @@ const AddEmergencyTasks = (props) => {
       defaultMessage={"Past time is not allowed"}
     />
   );
+
+  const getNonMedicationTaskTypeOptions = async () => {
+    setNonMedicationTaskTypeOptions(
+      nonMedicationTaskTypes
+        .map((nonMedicationTaskTypeOption) => {
+          return {
+            label: nonMedicationTaskTypeOption,
+            value: nonMedicationTaskTypeOption,
+          };
+        })
+        .sort((a, b) => a.label.localeCompare(b.label))
+    );
+  };
+
   const fetchDrugOrderConfig = async () => {
     setIsLoading(true);
     const drugOrderConfigResponse = await getDrugOrdersConfig();
@@ -258,17 +276,17 @@ const AddEmergencyTasks = (props) => {
       patientUuid: patientId,
       encounterUuid: encounterUuid.encounterUuid,
       intent: "ORDER",
-      taskType: "nursing_activity",
+      taskType: nonMedicationTaskType,
       status: "REQUESTED",
     };
     return nonMedicationPayload;
   };
 
   const handlePrimaryButtonClick = async () => {
-    updateIsSaveDisabled(true);
+    setIsSaveDisabled(true);
     const response = await saveEmergencyMedication(emergencyTask);
     if (response.status === 200) {
-      updateIsSaveDisabled(false);
+      setIsSaveDisabled(false);
       saveAdhocTasks();
     }
   };
@@ -295,7 +313,7 @@ const AddEmergencyTasks = (props) => {
       const nonMedicationTaskPayload = await createNonMedicationTaskPayload();
       const response = await saveNonMedicationTask(nonMedicationTaskPayload);
       if (response.status === 200) {
-        updateIsSaveDisabled(false);
+        setIsSaveDisabled(false);
         saveNonMedicationAdhocTasks();
       }
     }
@@ -305,13 +323,23 @@ const AddEmergencyTasks = (props) => {
     fetchDrugOrderConfig();
     fetchDrugFormDefaults();
     fetchAllProviders();
+    getNonMedicationTaskTypeOptions();
   }, []);
 
   const handleNonMedicationSaveButton = () => {
-    if (task && scheduleTime && !(_.isEmpty(task) || _.isEmpty(scheduleTime))) {
-      updateIsSaveDisabled(false);
+    if (
+      task &&
+      nonMedicationTaskType &&
+      scheduleTime &&
+      !(
+        _.isEmpty(task) ||
+        _.isEmpty(nonMedicationTaskType) ||
+        _.isEmpty(scheduleTime)
+      )
+    ) {
+      setIsSaveDisabled(false);
     } else {
-      updateIsSaveDisabled(true);
+      setIsSaveDisabled(true);
       setAtleastOneFieldFilled(false);
       if (task) {
         setAtleastOneFieldFilled(true);
@@ -333,9 +361,9 @@ const AddEmergencyTasks = (props) => {
         _.isEmpty(notes)
       )
     ) {
-      updateIsSaveDisabled(false);
+      setIsSaveDisabled(false);
     } else {
-      updateIsSaveDisabled(true);
+      setIsSaveDisabled(true);
       setAtleastOneFieldFilled(false);
       if (
         dosage ||
@@ -368,7 +396,7 @@ const AddEmergencyTasks = (props) => {
 
   useEffect(() => {
     handleNonMedicationSaveButton();
-  }, [task, scheduleTime]);
+  }, [task, scheduleTime, nonMedicationTaskType]);
 
   useEffect(() => {
     customValidation(administrationTime);
@@ -416,6 +444,7 @@ const AddEmergencyTasks = (props) => {
   const actionForInvalidTime = (invalid) => {
     setIsInvalidTime(invalid);
     setInvalidText(invalidTimeText24Hour);
+    setIsSaveDisabled(true);
   };
 
   return (
@@ -586,6 +615,17 @@ const AddEmergencyTasks = (props) => {
                   placeholder={"Enter a title for the task "}
                   maxCount={10}
                   rows={1}
+                />
+                <Dropdown
+                  id={"non-medication-task-type-dropdown"}
+                  onChange={(selectedItem) => {
+                    setNonMedicationTaskType(selectedItem?.value);
+                  }}
+                  placeholder={"Select Task Type"}
+                  titleText={"Task Type"}
+                  isRequired={true}
+                  options={nonMedicationTaskTypeOptions}
+                  width={"100%"}
                 />
                 <div className="time-info">
                   {enable24HourTime ? (

--- a/src/features/DisplayControls/NursingTasks/components/TaskTile.jsx
+++ b/src/features/DisplayControls/NursingTasks/components/TaskTile.jsx
@@ -7,7 +7,7 @@ import {
   getRelevantTaskStatus,
   iconType,
 } from "../utils/TaskTileUtils";
-import { TooltipDefinition } from "carbon-components-react";
+import { TooltipDefinition, Tag } from "carbon-components-react";
 import "../styles/TaskTile.scss";
 import DisplayTags from "../../../../components/DisplayTags/DisplayTags";
 import { IPDContext } from "../../../../context/IPDContext";
@@ -111,46 +111,58 @@ export default function TaskTile(props) {
               <DisplayTags drugOrder={dosingInstructions} />
             </div>
           )}
-          <div
-            className="tile-content-subtext"
-            style={{
-              color: isRelevantTask ? "#393939" : "#525252",
-              paddingLeft: "25px",
-            }}
-          >
-            <span>{dosage}</span>
-            {creator && !isSystemGeneratedTask(newMedicationNursingTask) && (
-              <span style={{ textTransform: "capitalize" }}>
-                {creatorName(creator.display)}
-              </span>
-            )}
-            {doseType && <span>&nbsp;-&nbsp;{doseType}</span>}
-            {drugRoute && <span>&nbsp;-&nbsp;{drugRoute}</span>}
-          </div>
-          {!(
-            dosingInstructions?.asNeeded &&
-            serviceType === asNeededPlaceholderConceptName
-          ) && (
-            <div className="tile-content-subtext">
-              <Clock />
-              <div className="tile-content-subtext-time">
-                &nbsp;
-                {enable24HourTime
-                  ? getTime(
-                      administeredTimeInEpochSeconds,
-                      startTime,
-                      "hh:mm",
-                      timeFormatFor24Hr
-                    )
-                  : getTime(
-                      administeredTimeInEpochSeconds,
-                      startTime,
-                      "hh:mm",
-                      timeFormatFor12Hr
-                    )}
+          <div className="tile-subcontent">
+            <div>
+              <div
+                className="tile-content-subtext"
+                style={{
+                  color: isRelevantTask ? "#393939" : "#525252",
+                  paddingLeft: "25px",
+                }}
+              >
+                <span>{dosage}</span>
+                {creator &&
+                  !isSystemGeneratedTask(newMedicationNursingTask) && (
+                    <span style={{ textTransform: "capitalize" }}>
+                      {creatorName(creator.display)}
+                    </span>
+                  )}
+                {doseType && <span>&nbsp;-&nbsp;{doseType}</span>}
+                {drugRoute && <span>&nbsp;-&nbsp;{drugRoute}</span>}
               </div>
+              {!(
+                dosingInstructions?.asNeeded &&
+                serviceType === asNeededPlaceholderConceptName
+              ) && (
+                <div className="tile-content-subtext">
+                  <Clock />
+                  <div className="tile-content-subtext-time">
+                    &nbsp;
+                    {enable24HourTime
+                      ? getTime(
+                          administeredTimeInEpochSeconds,
+                          startTime,
+                          "hh:mm",
+                          timeFormatFor24Hr
+                        )
+                      : getTime(
+                          administeredTimeInEpochSeconds,
+                          startTime,
+                          "hh:mm",
+                          timeFormatFor12Hr
+                        )}
+                  </div>
+                </div>
+              )}
             </div>
-          )}
+            <div>
+              {taskType && !isSystemGeneratedTask(newMedicationNursingTask) && (
+                <Tag type="blue">
+                  <span>{taskType.display}</span>
+                </Tag>
+              )}
+            </div>
+          </div>
           {isGroupedTask && <div className="more-info">({taskCount} more)</div>}
         </div>
       </div>

--- a/src/features/DisplayControls/NursingTasks/styles/NursingTasks.scss
+++ b/src/features/DisplayControls/NursingTasks/styles/NursingTasks.scss
@@ -113,6 +113,7 @@
 .nursing-task-tiles-container {
   display: flex;
   flex-wrap: wrap;
+  padding-bottom: 5px;
 }
 
 .date-text {

--- a/src/features/DisplayControls/NursingTasks/styles/TaskTile.scss
+++ b/src/features/DisplayControls/NursingTasks/styles/TaskTile.scss
@@ -162,3 +162,16 @@
   right: 0;
   padding-top: 5px;
 }
+
+.truncate-text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  width: 90%;
+}
+
+.tile-subcontent {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}

--- a/src/features/DisplayControls/NursingTasks/tests/NursingTasks.spec.jsx
+++ b/src/features/DisplayControls/NursingTasks/tests/NursingTasks.spec.jsx
@@ -463,7 +463,7 @@ describe("NursingTasks", () => {
         requestedStartTime: 1939452389000,
         requestedEndTime: 1939452389000,
         partOf: null,
-        taskType: { display: "nursing_activity" },
+        taskType: { display: "Non Medication Task" },
         creator: {
           uuid: "c1c21e11-3f10-11e4-adec-0800271c1b75",
           display: "bailly.rurangirwa",

--- a/src/features/DisplayControls/NursingTasks/tests/NursingTasksUtilsMockData.js
+++ b/src/features/DisplayControls/NursingTasks/tests/NursingTasksUtilsMockData.js
@@ -58,7 +58,7 @@ export const mockUpdateResponse = {
       partOf: null,
       taskType: {
         uuid: "a5ea9d94-f662-11ee-8850-0242ac120006",
-        display: "nursing_activity",
+        display: "Non Medication Task",
         links: [
           {
             rel: "self",
@@ -1230,7 +1230,7 @@ export const mockNonMedicationTileData = [
     startTime: "16:38",
     isDisabled: false,
     partOf: null,
-    taskType: { display: "nursing_activity" },
+    taskType: { display: "Non Medication Task" },
     creator: {
       uuid: "c1c21e11-3f10-11e4-adec-0800271c1b75",
       display: "bailly.rurangirwa",

--- a/src/features/DisplayControls/NursingTasks/tests/__snapshots__/AddEmergencyTasks.spec.jsx.snap
+++ b/src/features/DisplayControls/NursingTasks/tests/__snapshots__/AddEmergencyTasks.spec.jsx.snap
@@ -339,7 +339,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                       class="bx--label"
                       dir="auto"
                       for="Dosage Dropdown"
-                      id="downshift-3-label"
+                      id="downshift-4-label"
                     >
                       <div
                         class="titleText"
@@ -400,7 +400,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                       <div
                         aria-label="Choose an item"
                         class="bx--list-box__menu"
-                        id="downshift-3-menu"
+                        id="downshift-4-menu"
                         role="listbox"
                       />
                     </div>
@@ -417,7 +417,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                     class="bx--label"
                     dir="auto"
                     for="Route-Dropdown"
-                    id="downshift-4-label"
+                    id="downshift-5-label"
                   >
                     <div
                       class="titleText"
@@ -483,7 +483,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                     <div
                       aria-label="Choose an item"
                       class="bx--list-box__menu"
-                      id="downshift-4-menu"
+                      id="downshift-5-menu"
                       role="listbox"
                     />
                   </div>
@@ -609,7 +609,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                   class="bx--label"
                   dir="auto"
                   for="Provider-info"
-                  id="downshift-5-label"
+                  id="downshift-6-label"
                 >
                   <div
                     class="titleText"
@@ -675,7 +675,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                   <div
                     aria-label="Choose an item"
                     class="bx--list-box__menu"
-                    id="downshift-5-menu"
+                    id="downshift-6-menu"
                     role="listbox"
                   />
                 </div>
@@ -759,6 +759,88 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                   placeholder="Enter a title for the task "
                   rows="1"
                 />
+              </div>
+            </div>
+            <div
+              data-testid="select"
+            >
+              <div
+                class="bx--list-box__wrapper"
+              >
+                <label
+                  class="bx--label"
+                  dir="auto"
+                  for="non-medication-task-type-dropdown"
+                  id="downshift-7-label"
+                >
+                  <div
+                    class="titleText"
+                  >
+                    <span>
+                      Task Type 
+                    </span>
+                    <span
+                      class="required"
+                    >
+                      *
+                    </span>
+                  </div>
+                </label>
+                <div
+                  class="bx--combo-box bx--list-box"
+                >
+                  <div
+                    class="bx--list-box__field"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="bx--text-input bx--text-input--empty"
+                      id="non-medication-task-type-dropdown"
+                      placeholder="Select Task Type"
+                      role="combobox"
+                      style="width: 100%;"
+                      tabindex="0"
+                      title=""
+                      type="text"
+                      value=""
+                    />
+                    
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Open"
+                      class="bx--list-box__menu-icon"
+                      data-toggle="true"
+                      role="button"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        focusable="false"
+                        height="16"
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    aria-label="Choose an item"
+                    class="bx--list-box__menu"
+                    id="downshift-7-menu"
+                    role="listbox"
+                  />
+                </div>
               </div>
             </div>
             <div
@@ -1301,6 +1383,7 @@ exports[`AddEmergencyTasks should render the component with loading state 1`] = 
                           role="combobox"
                           style="width: 170px;"
                           tabindex="0"
+                          title=""
                           type="text"
                           value=""
                         />
@@ -1383,6 +1466,7 @@ exports[`AddEmergencyTasks should render the component with loading state 1`] = 
                         role="combobox"
                         style="width: 100%;"
                         tabindex="0"
+                        title=""
                         type="text"
                         value=""
                       />
@@ -1574,6 +1658,7 @@ exports[`AddEmergencyTasks should render the component with loading state 1`] = 
                       role="combobox"
                       style="width: 100%;"
                       tabindex="0"
+                      title=""
                       type="text"
                       value=""
                     />
@@ -1696,6 +1781,88 @@ exports[`AddEmergencyTasks should render the component with loading state 1`] = 
                   placeholder="Enter a title for the task "
                   rows="1"
                 />
+              </div>
+            </div>
+            <div
+              data-testid="select"
+            >
+              <div
+                class="bx--list-box__wrapper"
+              >
+                <label
+                  class="bx--label"
+                  dir="auto"
+                  for="non-medication-task-type-dropdown"
+                  id="downshift-3-label"
+                >
+                  <div
+                    class="titleText"
+                  >
+                    <span>
+                      Task Type 
+                    </span>
+                    <span
+                      class="required"
+                    >
+                      *
+                    </span>
+                  </div>
+                </label>
+                <div
+                  class="bx--combo-box bx--list-box"
+                >
+                  <div
+                    class="bx--list-box__field"
+                  >
+                    <input
+                      aria-autocomplete="list"
+                      aria-expanded="false"
+                      aria-haspopup="listbox"
+                      autocomplete="off"
+                      class="bx--text-input bx--text-input--empty"
+                      id="non-medication-task-type-dropdown"
+                      placeholder="Select Task Type"
+                      role="combobox"
+                      style="width: 100%;"
+                      tabindex="0"
+                      title=""
+                      type="text"
+                      value=""
+                    />
+                    
+                    <button
+                      aria-haspopup="true"
+                      aria-label="Open"
+                      class="bx--list-box__menu-icon"
+                      data-toggle="true"
+                      role="button"
+                      tabindex="-1"
+                      title="Open"
+                      type="button"
+                    >
+                      <svg
+                        aria-hidden="true"
+                        fill="currentColor"
+                        focusable="false"
+                        height="16"
+                        preserveAspectRatio="xMidYMid meet"
+                        viewBox="0 0 16 16"
+                        width="16"
+                        xmlns="http://www.w3.org/2000/svg"
+                      >
+                        <path
+                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
+                        />
+                      </svg>
+                    </button>
+                  </div>
+                  <div
+                    aria-label="Choose an item"
+                    class="bx--list-box__menu"
+                    id="downshift-3-menu"
+                    role="listbox"
+                  />
+                </div>
               </div>
             </div>
             <div

--- a/src/features/DisplayControls/NursingTasks/tests/__snapshots__/AddEmergencyTasks.spec.jsx.snap
+++ b/src/features/DisplayControls/NursingTasks/tests/__snapshots__/AddEmergencyTasks.spec.jsx.snap
@@ -339,7 +339,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                       class="bx--label"
                       dir="auto"
                       for="Dosage Dropdown"
-                      id="downshift-4-label"
+                      id="downshift-3-label"
                     >
                       <div
                         class="titleText"
@@ -400,7 +400,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                       <div
                         aria-label="Choose an item"
                         class="bx--list-box__menu"
-                        id="downshift-4-menu"
+                        id="downshift-3-menu"
                         role="listbox"
                       />
                     </div>
@@ -417,7 +417,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                     class="bx--label"
                     dir="auto"
                     for="Route-Dropdown"
-                    id="downshift-5-label"
+                    id="downshift-4-label"
                   >
                     <div
                       class="titleText"
@@ -483,7 +483,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                     <div
                       aria-label="Choose an item"
                       class="bx--list-box__menu"
-                      id="downshift-5-menu"
+                      id="downshift-4-menu"
                       role="listbox"
                     />
                   </div>
@@ -609,7 +609,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                   class="bx--label"
                   dir="auto"
                   for="Provider-info"
-                  id="downshift-6-label"
+                  id="downshift-5-label"
                 >
                   <div
                     class="titleText"
@@ -675,7 +675,7 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                   <div
                     aria-label="Choose an item"
                     class="bx--list-box__menu"
-                    id="downshift-6-menu"
+                    id="downshift-5-menu"
                     role="listbox"
                   />
                 </div>
@@ -759,88 +759,6 @@ exports[`AddEmergencyTasks should render the component 1`] = `
                   placeholder="Enter a title for the task "
                   rows="1"
                 />
-              </div>
-            </div>
-            <div
-              data-testid="select"
-            >
-              <div
-                class="bx--list-box__wrapper"
-              >
-                <label
-                  class="bx--label"
-                  dir="auto"
-                  for="non-medication-task-type-dropdown"
-                  id="downshift-7-label"
-                >
-                  <div
-                    class="titleText"
-                  >
-                    <span>
-                      Task Type 
-                    </span>
-                    <span
-                      class="required"
-                    >
-                      *
-                    </span>
-                  </div>
-                </label>
-                <div
-                  class="bx--combo-box bx--list-box"
-                >
-                  <div
-                    class="bx--list-box__field"
-                  >
-                    <input
-                      aria-autocomplete="list"
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      autocomplete="off"
-                      class="bx--text-input bx--text-input--empty"
-                      id="non-medication-task-type-dropdown"
-                      placeholder="Select Task Type"
-                      role="combobox"
-                      style="width: 100%;"
-                      tabindex="0"
-                      title=""
-                      type="text"
-                      value=""
-                    />
-                    
-                    <button
-                      aria-haspopup="true"
-                      aria-label="Open"
-                      class="bx--list-box__menu-icon"
-                      data-toggle="true"
-                      role="button"
-                      tabindex="-1"
-                      title="Open"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="currentColor"
-                        focusable="false"
-                        height="16"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                  <div
-                    aria-label="Choose an item"
-                    class="bx--list-box__menu"
-                    id="downshift-7-menu"
-                    role="listbox"
-                  />
-                </div>
               </div>
             </div>
             <div
@@ -1781,88 +1699,6 @@ exports[`AddEmergencyTasks should render the component with loading state 1`] = 
                   placeholder="Enter a title for the task "
                   rows="1"
                 />
-              </div>
-            </div>
-            <div
-              data-testid="select"
-            >
-              <div
-                class="bx--list-box__wrapper"
-              >
-                <label
-                  class="bx--label"
-                  dir="auto"
-                  for="non-medication-task-type-dropdown"
-                  id="downshift-3-label"
-                >
-                  <div
-                    class="titleText"
-                  >
-                    <span>
-                      Task Type 
-                    </span>
-                    <span
-                      class="required"
-                    >
-                      *
-                    </span>
-                  </div>
-                </label>
-                <div
-                  class="bx--combo-box bx--list-box"
-                >
-                  <div
-                    class="bx--list-box__field"
-                  >
-                    <input
-                      aria-autocomplete="list"
-                      aria-expanded="false"
-                      aria-haspopup="listbox"
-                      autocomplete="off"
-                      class="bx--text-input bx--text-input--empty"
-                      id="non-medication-task-type-dropdown"
-                      placeholder="Select Task Type"
-                      role="combobox"
-                      style="width: 100%;"
-                      tabindex="0"
-                      title=""
-                      type="text"
-                      value=""
-                    />
-                    
-                    <button
-                      aria-haspopup="true"
-                      aria-label="Open"
-                      class="bx--list-box__menu-icon"
-                      data-toggle="true"
-                      role="button"
-                      tabindex="-1"
-                      title="Open"
-                      type="button"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        fill="currentColor"
-                        focusable="false"
-                        height="16"
-                        preserveAspectRatio="xMidYMid meet"
-                        viewBox="0 0 16 16"
-                        width="16"
-                        xmlns="http://www.w3.org/2000/svg"
-                      >
-                        <path
-                          d="M8 11L3 6 3.7 5.3 8 9.6 12.3 5.3 13 6z"
-                        />
-                      </svg>
-                    </button>
-                  </div>
-                  <div
-                    aria-label="Choose an item"
-                    class="bx--list-box__menu"
-                    id="downshift-3-menu"
-                    role="listbox"
-                  />
-                </div>
               </div>
             </div>
             <div

--- a/src/features/DisplayControls/NursingTasks/tests/__snapshots__/TaskTile.spec.jsx.snap
+++ b/src/features/DisplayControls/NursingTasks/tests/__snapshots__/TaskTile.spec.jsx.snap
@@ -60,20 +60,27 @@ exports[`TaskTile should match the snapshot for grouped task 1`] = `
           </div>
         </div>
         <div
-          class="tile-content-subtext"
-          style="color: rgb(82, 82, 82); padding-left: 25px;"
+          class="tile-subcontent"
         >
-          <span />
-        </div>
-        <div
-          class="tile-content-subtext"
-        >
-          <test-file-stub />
-          <div
-            class="tile-content-subtext-time"
-          >
-             Invalid date
+          <div>
+            <div
+              class="tile-content-subtext"
+              style="color: rgb(82, 82, 82); padding-left: 25px;"
+            >
+              <span />
+            </div>
+            <div
+              class="tile-content-subtext"
+            >
+              <test-file-stub />
+              <div
+                class="tile-content-subtext-time"
+              >
+                 Invalid date
+              </div>
+            </div>
           </div>
+          <div />
         </div>
         <div
           class="more-info"
@@ -153,25 +160,32 @@ exports[`TaskTile should match the snapshot for non grouped task 1`] = `
           </div>
         </div>
         <div
-          class="tile-content-subtext"
-          style="color: rgb(82, 82, 82); padding-left: 25px;"
+          class="tile-subcontent"
         >
-          <span>
-            1ml
-          </span>
-          <span>
-             - Oral
-          </span>
-        </div>
-        <div
-          class="tile-content-subtext"
-        >
-          <test-file-stub />
-          <div
-            class="tile-content-subtext-time"
-          >
-             16:00 - 07:23 (actual)
+          <div>
+            <div
+              class="tile-content-subtext"
+              style="color: rgb(82, 82, 82); padding-left: 25px;"
+            >
+              <span>
+                1ml
+              </span>
+              <span>
+                 - Oral
+              </span>
+            </div>
+            <div
+              class="tile-content-subtext"
+            >
+              <test-file-stub />
+              <div
+                class="tile-content-subtext-time"
+              >
+                 16:00 - 07:23 (actual)
+              </div>
+            </div>
           </div>
+          <div />
         </div>
       </div>
     </div>


### PR DESCRIPTION
JIRA -> [BAH-4034](https://bahmni.atlassian.net/browse/BAH-4034)

In this PR, the following changes have been introduced:
1. **Remove Hardcoded Concepts**: Eliminate the hardcoded values for `nursing_activity` in the IPD frontend code.
2. **Implement Configuration-Based Approach**: Introduce a configuration array named `nonMedicationTasks` that lists all available non-medication task concepts and ensure the frontend code reads from this configuration array to populate the relevant dropdowns. This field is optional, with the dropdown hidden if the `nonMedicationTasks` is not defined or empty an array.
3. **Maintain Functionality**: The existing functionality related to non-medication tasks remains intact after refactoring. The task type selected will now be visible on the Task Tile as a chip.

| Task Tile With Task Type | Task Tile With Slider | Updated Non Medication Slider |
|-|-|-|
| ![Screenshot 2024-07-18 at 6 54 12 PM](https://github.com/user-attachments/assets/dfc0a156-65ab-4818-b798-0b33ffa5a209) | ![Screenshot 2024-07-18 at 6 54 06 PM](https://github.com/user-attachments/assets/e7764de5-c875-4b36-a97a-e6704af0ba36) | ![Screenshot 2024-07-18 at 7 11 36 PM](https://github.com/user-attachments/assets/804386c0-5e21-483b-a7f1-de38726b35f5) |

