### PR TITLE
BAH-4060 | Refactor. Filter IP Medications based on config

### DIFF
--- a/src/features/DisplayControls/DrugChart/utils/DrugChartUtils.js
+++ b/src/features/DisplayControls/DrugChart/utils/DrugChartUtils.js
@@ -21,7 +21,7 @@ export const fetchMedications = async (
   try {
     return await axios.get(FETCH_MEDICATIONS_URL);
   } catch (error) {
-    return {error};
+    return { error };
   }
 };
 
@@ -29,10 +29,7 @@ export const transformDrugOrders = (orders) => {
   const { ipdDrugOrders, emergencyMedications } = orders;
   const medicationData = {};
   ipdDrugOrders.forEach((order) => {
-    if (
-      order.drugOrder?.careSetting === "INPATIENT" &&
-      order.drugOrderSchedule
-    ) {
+    if (order.drugOrderSchedule) {
       const {
         dosingInstructions,
         drug,

--- a/src/features/DisplayControls/Treatments/components/Treatments.jsx
+++ b/src/features/DisplayControls/Treatments/components/Treatments.jsx
@@ -13,7 +13,6 @@ import {
   EditDrugChart,
   StopDrugChart,
   NoTreatmentsMessage,
-  isIPDDrugOrder,
   setDosingInstructions,
   getDrugName,
   stopDrugOrders,
@@ -24,7 +23,7 @@ import {
   getStopReason,
   getSlotsForAnOrderAndServiceType,
 } from "../utils/TreatmentsUtils";
-import { getCookies } from "../../../../utils/CommonUtils";
+import { isIPDrugOrder, getCookies } from "../../../../utils/CommonUtils";
 import {
   ForbiddenErrorMessage,
   GenericErrorMessage,
@@ -58,7 +57,10 @@ const Treatments = (props) => {
     provider,
   } = useContext(SliderContext);
   const { config, handleAuditEvent } = useContext(IPDContext);
-  const { enable24HourTime = {} } = config;
+  const {
+    enable24HourTime = {},
+    allMedicinesInPrescriptionAvailableForIPD = true,
+  } = config;
   const refreshDisplayControl = useContext(RefreshDisplayControl);
   const [treatments, setTreatments] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -273,9 +275,13 @@ const Treatments = (props) => {
   };
 
   const modifyPrescribedTreatmentData = async (drugOrders) => {
+    if (!allMedicinesInPrescriptionAvailableForIPD) {
+      drugOrders = drugOrders.filter((drugOrderObject) =>
+        isIPDrugOrder(drugOrderObject.drugOrder)
+      );
+    }
     const prescribedTreatments = await Promise.all(
       drugOrders
-        .filter((drugOrderObject) => isIPDDrugOrder(drugOrderObject))
         .filter(
           (drugOrderObject) =>
             !isDrugOrderStoppedWithoutAdministration(drugOrderObject)

--- a/src/features/DisplayControls/Treatments/tests/Treatments.spec.jsx
+++ b/src/features/DisplayControls/Treatments/tests/Treatments.spec.jsx
@@ -105,7 +105,84 @@ describe("Treatments", () => {
     });
   });
 
-  it("should not show OPD treatments", async () => {
+  it("should show opd and ipd treatments", async () => {
+    const treatments = [
+      {
+        drugOrder: {
+          uuid: "1",
+          effectiveStartDate: 1704785404,
+          dateStopped: null,
+          dateActivated: 1704785404,
+          scheduledDate: 1704785404,
+          drug: {
+            name: "Drug 1",
+          },
+          dosingInstructions: {
+            dose: 1,
+            doseUnits: "mg",
+            route: "Oral",
+            frequency: "Once a day",
+            administrationInstructions:
+              '{"instructions":"As directed","additionalInstructions":"all good"}',
+          },
+          duration: 7,
+          durationUnits: "Day(s)",
+          careSetting: "OUTPATIENT",
+        },
+        provider: {
+          name: "Dr. John Doe",
+        },
+      },
+      {
+        drugOrder: {
+          uuid: "2",
+          effectiveStartDate: 1704785404,
+          dateStopped: null,
+          dateActivated: 1704785404,
+          scheduledDate: 1704785404,
+          drug: {
+            name: "Drug 2",
+          },
+          dosingInstructions: {
+            dose: 1,
+            doseUnits: "mg",
+            route: "Oral",
+            frequency: "Once a day",
+            administrationInstructions:
+              '{"instructions":"As directed","additionalInstructions":"all good"}',
+          },
+          duration: 7,
+          durationUnits: "Day(s)",
+          careSetting: "INPATIENT",
+        },
+        provider: {
+          name: "Dr. John Doe",
+        },
+      },
+    ];
+    const updatedAllMedications = {
+      ...mockAllMedicationsProviderValue,
+      data: {
+        emergencyMedications: [],
+        ipdDrugOrders: treatments,
+      },
+    };
+    const { getByText } = render(
+      <IPDContext.Provider value={{ config: mockConfig, isReadMode: false }}>
+        <SliderContext.Provider value={mockProviderValue}>
+          <AllMedicationsContext.Provider value={updatedAllMedications}>
+            <Treatments patientId="3ae1ee52-e9b2-4934-876d-30711c0e3e2f" />
+          </AllMedicationsContext.Provider>
+        </SliderContext.Provider>
+      </IPDContext.Provider>
+    );
+    await waitFor(() => {
+      expect(getByText("Drug 1")).toBeTruthy();
+      expect(getByText("Drug 2")).toBeTruthy();
+    });
+  });
+
+  it("should not show OPD treatments only when allMedicinesInPrescriptionAvailableForIPD config is false", async () => {
     const treatments = [
       {
         drugOrder: {
@@ -140,7 +217,15 @@ describe("Treatments", () => {
       },
     };
     const { getByText } = render(
-      <IPDContext.Provider value={{ config: mockConfig, isReadMode: false }}>
+      <IPDContext.Provider
+        value={{
+          config: {
+            ...mockConfig,
+            allMedicinesInPrescriptionAvailableForIPD: false,
+          },
+          isReadMode: false,
+        }}
+      >
         <SliderContext.Provider value={mockProviderValue}>
           <AllMedicationsContext.Provider value={updatedAllMedications}>
             <Treatments patientId="3ae1ee52-e9b2-4934-876d-30711c0e3e2f" />
@@ -544,7 +629,13 @@ describe("Treatments", () => {
     });
 
     const { getAllByText, container } = render(
-      <IPDContext.Provider value={{ config: mockConfig, isReadMode: false, handleAuditEvent: mockHandleAuditEvent }}>
+      <IPDContext.Provider
+        value={{
+          config: mockConfig,
+          isReadMode: false,
+          handleAuditEvent: mockHandleAuditEvent,
+        }}
+      >
         <SliderContext.Provider value={mockProviderValue}>
           <AllMedicationsContext.Provider value={updatedAllMedications}>
             <Treatments patientId="3ae1ee52-e9b2-4934-876d-30711c0e3e2f" />
@@ -564,7 +655,9 @@ describe("Treatments", () => {
       expect(getEncounterType).toHaveBeenCalledWith("Consultation");
       expect(stopDrugOrders).toHaveBeenCalled();
     });
-    expect(mockHandleAuditEvent).toHaveBeenCalledWith('STOP_SCHEDULED_MEDICATION_TASK')
+    expect(mockHandleAuditEvent).toHaveBeenCalledWith(
+      "STOP_SCHEDULED_MEDICATION_TASK"
+    );
   });
 
   it("should update the drug status after the stop drug api call is success", async () => {

--- a/src/features/DisplayControls/Treatments/utils/TreatmentsUtils.js
+++ b/src/features/DisplayControls/Treatments/utils/TreatmentsUtils.js
@@ -133,10 +133,6 @@ export const NoTreatmentsMessage = (
   />
 );
 
-export const isIPDDrugOrder = (drugOrderObject) => {
-  return drugOrderObject.drugOrder.careSetting === "INPATIENT";
-};
-
 export const isDrugOrderStoppedWithoutAdministration = (drugOrderObject) => {
   return (
     drugOrderObject.drugOrder.dateStopped &&

--- a/src/utils/CommonUtils.jsx
+++ b/src/utils/CommonUtils.jsx
@@ -357,6 +357,13 @@ export const mockConfigFor12HourFormat = {
   },
 };
 
-export const isSystemGeneratedTask =(task)=>{
-  return task?.creator?.uuid === DAEMON_USER.uuid || task?.creator?.name === DAEMON_USER.name; 
-}
+export const isSystemGeneratedTask = (task) => {
+  return (
+    task?.creator?.uuid === DAEMON_USER.uuid ||
+    task?.creator?.name === DAEMON_USER.name
+  );
+};
+
+export const isIPDrugOrder = (drugOrder) => {
+  return drugOrder.careSetting === "INPATIENT";
+};


### PR DESCRIPTION
As part of this PR, the default filtering for `INPATIENT` medications is removed and only filtered when allMedicinesInPrescriptionAvailableForIPD is set to `false` in ipdDashboard/app.json config.

Prescriptions across OPD and IPD Visit:
<img width="1332" alt="image" src="https://github.com/user-attachments/assets/16c5a861-4002-45ec-8473-8df007b22f41">

Both are shown in Treatments display control when config is undefined or set to true:
<img width="1528" alt="image" src="https://github.com/user-attachments/assets/27562b50-11e4-49ba-89a9-b0b7a4a700e9">

When config is set to `false`:
<img width="1543" alt="image" src="https://github.com/user-attachments/assets/fbce90c1-8641-4ef4-a476-8c45b5d84767">

