### PR TITLE
BAH-4739 | Display infusion parameters (Rate, Additives) in IPD Dashboard and Drug Chart

### DIFF
--- a/src/components/Notification/Notification.jsx
+++ b/src/components/Notification/Notification.jsx
@@ -10,6 +10,7 @@ export default function Notification(props) {
   const { hostData, hostApi } = props;
   const { notificationKind, messageId, messageDuration = 2000 } = hostData;
   const getMessage = (messageId) => {
+    if (!messageId) return null;
     return (
       <I18nProvider>
         <FormattedMessage id={messageId} />

--- a/src/components/Notification/__snapshots__/Notification.spec.jsx.snap
+++ b/src/components/Notification/__snapshots__/Notification.spec.jsx.snap
@@ -43,9 +43,7 @@ exports[`Notification should show success notification 1`] = `
           >
             <p
               class="bx--inline-notification__title"
-            >
-              <div />
-            </p>
+            />
             <div
               class="bx--inline-notification__subtitle"
             />
@@ -99,9 +97,7 @@ exports[`Notification should show warning notification 1`] = `
           >
             <p
               class="bx--inline-notification__title"
-            >
-              <div />
-            </p>
+            />
             <div
               class="bx--inline-notification__subtitle"
             />

--- a/src/features/DisplayControls/DrugChart/components/DrugListCell.jsx
+++ b/src/features/DisplayControls/DrugChart/components/DrugListCell.jsx
@@ -20,6 +20,8 @@ export default function DrugListCell(props) {
   const showInstructionsIcon =
     instructions?.instructions ||
     instructions?.additionalInstructions ||
+    instructions?.rate ||
+    instructions?.additives ||
     notes ||
     orderReasonText;
   const administrationInfo = [];
@@ -52,6 +54,31 @@ export default function DrugListCell(props) {
           )}
           Additional Instructions:&nbsp;
           {dosingInstructions?.instructions?.additionalInstructions}
+        </>
+      )}
+      {dosingInstructions?.instructions?.rate && (
+        <>
+          {(dosingInstructions?.instructions?.instructions ||
+            dosingInstructions?.instructions?.additionalInstructions) && (
+            <>
+              <br />
+              <div className="tooltip-content-separater" />
+            </>
+          )}
+          Rate:&nbsp;{dosingInstructions?.instructions?.rate} ml/hr
+        </>
+      )}
+      {dosingInstructions?.instructions?.additives && (
+        <>
+          {(dosingInstructions?.instructions?.instructions ||
+            dosingInstructions?.instructions?.additionalInstructions ||
+            dosingInstructions?.instructions?.rate) && (
+            <>
+              <br />
+              <div className="tooltip-content-separater" />
+            </>
+          )}
+          Additives:&nbsp;{dosingInstructions?.instructions?.additives}
         </>
       )}
       {orderReasonText && (

--- a/src/features/DisplayControls/DrugChart/tests/DrugChartUtils.spec.js
+++ b/src/features/DisplayControls/DrugChart/tests/DrugChartUtils.spec.js
@@ -213,5 +213,83 @@ describe("DrugChartUtils", () => {
         "Take with water"
       );
     });
+
+    const createOrder = (doseUnits) => ({
+      drugOrder: {
+        uuid: "order-1",
+        careSetting: "INPATIENT",
+        drug: { name: "Drug A" },
+        duration: 5,
+        durationUnits: "Day(s)",
+        dosingInstructions: {
+          dose: 10,
+          doseUnits,
+          route: "Oral",
+          frequency: { display: "Daily" },
+          administrationInstructions: "{}",
+        },
+      },
+      drugOrderSchedule: { slotStartTime: 1000 },
+    });
+
+    it("should concatenate compact units (ml, mg, mcg) with dose", () => {
+      ["ml", "mg", "mcg"].forEach((unit) => {
+        const result = transformDrugOrders({
+          ipdDrugOrders: [createOrder(unit)],
+          emergencyMedications: [],
+        });
+        const med = result["order-1"];
+        expect(med.dosingInstructions.dosage).toBe(`10${unit}`);
+        expect(med.dosingInstructions.doseUnits).toBeUndefined();
+      });
+    });
+
+    it("should separate non-compact units (e.g., Tablet) from dose", () => {
+      const result = transformDrugOrders({
+        ipdDrugOrders: [createOrder("Tablet")],
+        emergencyMedications: [],
+      });
+      const med = result["order-1"];
+      expect(med.dosingInstructions.dosage).toBe(10);
+      expect(med.dosingInstructions.doseUnits).toBe("Tablet");
+    });
+
+    it("should handle compact units in emergency medications", () => {
+      const result = transformDrugOrders({
+        ipdDrugOrders: [],
+        emergencyMedications: [
+          {
+            uuid: "emerg-1",
+            dose: 20,
+            doseUnits: { display: "mcg" },
+            drug: { uuid: "drug-1", display: "Drug B" },
+            route: { display: "IV" },
+            administeredDateTime: 2000000,
+          },
+        ],
+      });
+      const med = result["emerg-1"];
+      expect(med.dosingInstructions.dosage).toBe("20mcg");
+      expect(med.dosingInstructions.doseUnits).toBeUndefined();
+    });
+
+    it("should handle non-compact units in emergency medications", () => {
+      const result = transformDrugOrders({
+        ipdDrugOrders: [],
+        emergencyMedications: [
+          {
+            uuid: "emerg-1",
+            dose: 2,
+            doseUnits: { display: "Tablet" },
+            drug: { uuid: "drug-1", display: "Drug C" },
+            route: { display: "Oral" },
+            administeredDateTime: 2000000,
+          },
+        ],
+      });
+      const med = result["emerg-1"];
+      expect(med.dosingInstructions.dosage).toBe(2);
+      expect(med.dosingInstructions.doseUnits).toBe("Tablet");
+    });
   });
 });

--- a/src/features/DisplayControls/DrugChart/tests/DrugChartUtils.spec.js
+++ b/src/features/DisplayControls/DrugChart/tests/DrugChartUtils.spec.js
@@ -4,6 +4,7 @@ import {
   getNextShiftDetails,
   getPreviousShiftDetails,
   getDateTime,
+  transformDrugOrders,
 } from "../utils/DrugChartUtils";
 import axios from "axios";
 import { mockResponse } from "./DrugChartUtilsMockData";
@@ -137,5 +138,80 @@ describe("DrugChartUtils", () => {
     const time = "08:00";
     const updatedDateTime = 1704441600000; // 5th Jan 2024 08:00
     expect(getDateTime(date, time)).toEqual(updatedDateTime);
+  });
+  describe("transformDrugOrders - dosage formatting", () => {
+    it("should parse rate and additives from administrationInstructions JSON", () => {
+      const result = transformDrugOrders({
+        ipdDrugOrders: [
+          {
+            drugOrder: {
+              uuid: "order-2",
+              careSetting: "INPATIENT",
+              drug: { name: "Normal Saline IV" },
+              duration: 7,
+              durationUnits: "Day(s)",
+              dosingInstructions: {
+                dose: 100,
+                doseUnits: "ml",
+                route: "Intravenous",
+                frequency: { display: "Once daily" },
+                administrationInstructions: JSON.stringify({
+                  instructions: "For IV infusion",
+                  additionalInstructions: "Monitor vitals",
+                  rate: 100,
+                  additives: "10 mEq KCl in saline",
+                }),
+              },
+            },
+            drugOrderSchedule: { slotStartTime: 1000 },
+          },
+        ],
+        emergencyMedications: [],
+      });
+      const med = result["order-2"];
+      expect(med.dosingInstructions.instructions.rate).toBe(100);
+      expect(med.dosingInstructions.instructions.additives).toBe(
+        "10 mEq KCl in saline"
+      );
+      expect(med.dosingInstructions.instructions.instructions).toBe(
+        "For IV infusion"
+      );
+      expect(med.dosingInstructions.instructions.additionalInstructions).toBe(
+        "Monitor vitals"
+      );
+    });
+
+    it("should handle missing rate and additives in administrationInstructions", () => {
+      const result = transformDrugOrders({
+        ipdDrugOrders: [
+          {
+            drugOrder: {
+              uuid: "order-3",
+              careSetting: "INPATIENT",
+              drug: { name: "Paracetamol" },
+              duration: 5,
+              durationUnits: "Day(s)",
+              dosingInstructions: {
+                dose: 1,
+                doseUnits: "Tablet",
+                route: "Oral",
+                frequency: { display: "Three times daily" },
+                administrationInstructions: JSON.stringify({
+                  instructions: "Take with water",
+                }),
+              },
+            },
+            drugOrderSchedule: { slotStartTime: 2000 },
+          },
+        ],
+        emergencyMedications: [],
+      });
+      const med = result["order-3"];
+      expect(med.dosingInstructions.instructions.rate).toBeUndefined();
+      expect(med.dosingInstructions.instructions.additives).toBeUndefined();
+      expect(med.dosingInstructions.instructions.instructions).toBe(
+        "Take with water"
+      );
+    });
   });
 });

--- a/src/features/DisplayControls/DrugChart/utils/DrugChartUtils.js
+++ b/src/features/DisplayControls/DrugChart/utils/DrugChartUtils.js
@@ -42,7 +42,8 @@ export const transformDrugOrders = (orders) => {
         doseUnits;
       if (
         dosingInstructions.doseUnits?.toLowerCase() === "ml" ||
-        dosingInstructions.doseUnits?.toLowerCase() === "mg"
+        dosingInstructions.doseUnits?.toLowerCase() === "mg" ||
+        dosingInstructions.doseUnits?.toLowerCase() === "mcg"
       ) {
         dosage = dosingInstructions.dose + dosingInstructions.doseUnits;
       } else {
@@ -83,7 +84,8 @@ export const transformDrugOrders = (orders) => {
       doseUnits;
     if (
       medication.doseUnits?.display?.toLowerCase() === "ml" ||
-      medication.doseUnits?.display?.toLowerCase() === "mg"
+      medication.doseUnits?.display?.toLowerCase() === "mg" ||
+      medication.doseUnits?.display?.toLowerCase() === "mcg"
     ) {
       dosage = medication.dose + medication.doseUnits.display;
     } else {

--- a/src/features/DisplayControls/Treatments/components/ExpandableRowData.jsx
+++ b/src/features/DisplayControls/Treatments/components/ExpandableRowData.jsx
@@ -31,6 +31,24 @@ const ExpandableRowData = (props) => {
     };
   }
 
+  if (expandTreatmentData.rate) {
+    verticalTabsData["Rate"] = {
+      data: `${expandTreatmentData.rate} ml/hr`,
+      additionalData: [
+        fetchAdditionalData(expandTreatmentData.recordedDateTime),
+      ],
+    };
+  }
+
+  if (expandTreatmentData.additives) {
+    verticalTabsData["Additives"] = {
+      data: expandTreatmentData.additives,
+      additionalData: [
+        fetchAdditionalData(expandTreatmentData.recordedDateTime),
+      ],
+    };
+  }
+
   if (expandTreatmentData.approverNotes) {
     verticalTabsData["Acknowledgement Note"] = {
       data: expandTreatmentData.approverNotes,

--- a/src/features/DisplayControls/Treatments/components/Treatments.jsx
+++ b/src/features/DisplayControls/Treatments/components/Treatments.jsx
@@ -358,6 +358,10 @@ const Treatments = (props) => {
               additionalInstructions: drugOrderObject.additionalInstructions
                 ? drugOrderObject.additionalInstructions
                 : "",
+              rate: drugOrderObject.rate ? drugOrderObject.rate : null,
+              additives: drugOrderObject.additives
+                ? drugOrderObject.additives
+                : null,
               recordedDateTime: formatDate(
                 drugOrder.dateActivated,
                 defaultDateTimeFormat
@@ -379,6 +383,8 @@ const Treatments = (props) => {
         id: treatment.id,
         instructions: treatment.additionalData.instructions,
         additionalInstructions: treatment.additionalData.additionalInstructions,
+        rate: treatment.additionalData.rate,
+        additives: treatment.additionalData.additives,
         recordedDateTime: treatment.additionalData.recordedDateTime,
         provider: treatment.providerName,
         stopReason: treatment.additionalData.stopReason,

--- a/src/features/DisplayControls/Treatments/utils/TreatmentsUtils.js
+++ b/src/features/DisplayControls/Treatments/utils/TreatmentsUtils.js
@@ -103,6 +103,12 @@ export const updateDrugOrderList = (drugOrderList) => {
       administrationInstructions.additionalInstructions
         ? administrationInstructions.additionalInstructions
         : "";
+    ipdDrugOrder.rate = administrationInstructions.rate
+      ? administrationInstructions.rate
+      : null;
+    ipdDrugOrder.additives = administrationInstructions.additives
+      ? administrationInstructions.additives
+      : null;
   });
   return drugOrderList;
 };
@@ -171,6 +177,8 @@ export const getDrugName = (drugOrderObject) => {
     drugOrder.drug &&
     (drugOrderObject.instructions ||
       drugOrderObject.additionalInstructions ||
+      drugOrderObject.rate ||
+      drugOrderObject.additives ||
       drugOrder.orderReasonConcept ||
       drugOrder.orderReasonText);
 

--- a/src/features/DisplayControls/Vitals/components/Vitals.jsx
+++ b/src/features/DisplayControls/Vitals/components/Vitals.jsx
@@ -76,6 +76,10 @@ const Vitals = (props) => {
         patientId,
         vitalsConfig.vitalsHistoryConceptValues
       );
+      if (!vitalsHistoryList) {
+        updateIsLoading(false);
+        return;
+      }
       const conceptDetails = getConceptDetails(
         vitalsConfig.latestVitalsConceptValues,
         vitalsHistoryList.conceptDetails

--- a/src/features/DrugChartSlider/components/DrugInstructions.jsx
+++ b/src/features/DrugChartSlider/components/DrugInstructions.jsx
@@ -1,8 +1,10 @@
 import React from "react";
 import { TextArea } from "carbon-components-react";
 import PropTypes from "prop-types";
+import { useIntl } from "react-intl";
 
 export const DrugInstructions = ({ hostData }) => {
+  const intl = useIntl();
   return (
     <>
       <div className="instructions">
@@ -27,6 +29,36 @@ export const DrugInstructions = ({ hostData }) => {
           disabled
         />
       </div>
+      {hostData?.drugOrder?.rate && (
+        <div className="infusion-rate">
+          <TextArea
+            className="infusion-rate-field"
+            readOnly
+            rows={1}
+            value={String(hostData.drugOrder.rate)}
+            labelText={intl.formatMessage({
+              id: "DRUG_CHART_MODAL_RATE",
+              defaultMessage: "Rate (ml/hr)",
+            })}
+            disabled
+          />
+        </div>
+      )}
+      {hostData?.drugOrder?.additives && (
+        <div className="additives">
+          <TextArea
+            className="additives-field"
+            readOnly
+            rows={1}
+            value={hostData.drugOrder.additives}
+            labelText={intl.formatMessage({
+              id: "DRUG_CHART_MODAL_ADDITIVES",
+              defaultMessage: "Additives",
+            })}
+            disabled
+          />
+        </div>
+      )}
     </>
   );
 };
@@ -36,6 +68,8 @@ DrugInstructions.propTypes = {
     drugOrder: PropTypes.shape({
       instructions: PropTypes.string,
       additionalInstructions: PropTypes.string,
+      rate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      additives: PropTypes.string,
     }),
   }),
 };

--- a/src/features/DrugChartSlider/tests/DrugInstructions.spec.jsx
+++ b/src/features/DrugChartSlider/tests/DrugInstructions.spec.jsx
@@ -1,5 +1,6 @@
 import React from "react";
 import { render } from "@testing-library/react";
+import { IntlProvider } from "react-intl";
 import { DrugInstructions } from "../components/DrugInstructions";
 
 const mockHostData = {
@@ -11,7 +12,11 @@ const mockHostData = {
 
 describe("DrugInstructions", () => {
   it("should match snapshot", () => {
-    const { container } = render(<DrugInstructions hostData={mockHostData} />);
+    const { container } = render(
+      <IntlProvider locale="en">
+        <DrugInstructions hostData={mockHostData} />
+      </IntlProvider>
+    );
     expect(container).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
**Description:**

  **Summary**

  - Display Rate and Additives fields in the Drug Chart instruction panel, shown only when values are present
  - Pass Rate and Additives through the Treatments data pipeline and display in the IPD Medications section and expandable row
  - Fix compact dose unit display (e.g., 50ml, 14mcg) in the Drug List Cell for ml, mg, mcg units
  - Fix mcg dose unit display in Drug Chart
  - Fix test suite failures on Node v18 (unhandled promise rejections in Vitals and Notification components)

  **Test plan**

  - Prescribe a medication with ml/kg, Rate and Additives — verify both appear in the Drug Chart instruction panel
  - Verify Rate and Additives display in the IPD Medications section and expandable row
  - Verify dose displays as 50ml / 14mcg (compact) vs 2 Tablet (spaced) in the Drug List Cell
  - Run npm test — all suites pass on Node v18